### PR TITLE
Handle PG 11, change index operations lock timeout, plus various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class AddAdminToUsers < ActiveRecord::Migration[5.2]
 end
 ```
 
-If the `users` table is large, running this migration on a live Postgres database will likely cause downtime. **Safe PG Migrations** hooks into Active Record so that the following gets executed instead:
+If the `users` table is large, running this migration on a live Postgres 9 database will likely cause downtime. **Safe PG Migrations** hooks into Active Record so that the following gets executed instead:
 
 ```rb
 class AddAdminToUsers < ActiveRecord::Migration[5.2]
@@ -69,19 +69,19 @@ Active Record means developers don't have to be proficient in SQL to interact wi
 
 ### Lock timeout
 
-Most DDL operations (e.g. adding a column, removing a column or adding a default value to a column) take an `ACCESS EXCLUSIVE` lock on the table they are altering. While these operations wait to acquire their lock, other statements are blocked. Before running a migration, **Safe PG Migrations** sets a short lock timeout so that statements are not blocked for too long.
+Most DDL operations (e.g. adding a column, removing a column or adding a default value to a column) take an `ACCESS EXCLUSIVE` lock on the table they are altering. While these operations wait to acquire their lock, other statements are blocked. Before running a migration, **Safe PG Migrations** sets a short lock timeout (default to 5 seconds) so that statements are not blocked for too long.
 
 See [PostgreSQL Alter Table and Long Transactions](http://www.joshuakehn.com/2017/9/9/postgresql-alter-table-and-long-transactions.html) and [Migrations and Long Transactions](https://www.fin.com/post/2018/1/migrations-and-long-transactions) for detailed explanations of the matter.
 
 ### Statement timeout
 
-Adding a foreign key or a not-null constraint can take a lot of time on a large table. The problem is that those operations take `ACCESS EXCLUSIVE` locks. We clearly don't want them to hold these locks for too long. Thus, **Safe PG Migrations** runs them with a short statement timeout.
+Adding a foreign key or a not-null constraint can take a lot of time on a large table. The problem is that those operations take `ACCESS EXCLUSIVE` locks. We clearly don't want them to hold these locks for too long. Thus, **Safe PG Migrations** runs them with a short statement timeout (default to 5 seconds).
 
 See [Zero-downtime Postgres migrations - the hard parts](https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/) for a detailed explanation on the subject.
 
 ### Prevent wrapping migrations in transaction
 
-When **Safe PG Migrations** is enabled (which is the case by default if `Rails.env.production?` is true), migrations are not wrapped in a transaction. This is for several reasons:
+When **Safe PG Migrations** is used, migrations are not wrapped in a transaction. This is for several reasons:
 
 - We want to release locks as soon as possible.
 - In order to be able to retry statements that have failed because of a lock timeout, we have to be outside a transaction.
@@ -90,6 +90,8 @@ When **Safe PG Migrations** is enabled (which is the case by default if `Rails.e
 Note that if a migration fails, it won't be rollbacked. This can result in migrations being partially applied. In that case, they need to be manually reverted.
 
 ### Safe `add_column`
+
+#### Pre Postgres 11 behavior
 
 Adding a column with a default value and a not-null constraint is [dangerous](https://wework.github.io/data/2015/11/05/add-columns-with-default-values-to-large-tables-in-rails-postgres/).
 
@@ -102,17 +104,94 @@ Adding a column with a default value and a not-null constraint is [dangerous](ht
 
 Note: the addition of the not null constraint may timeout. In that case, you may want to add the not-null constraint as initially not valid and validate it in a separate statement. See [Adding a not-null constraint on Postgres with minimal locking](https://medium.com/doctolib-engineering/adding-a-not-null-constraint-on-pg-faster-with-minimal-locking-38b2c00c4d1c).
 
+#### Postgres 11 behavior
+
+**Safe PG Migrations** gracefully handle the upgrade to PG11 by **not** backfilling default value for existing rows, as the [database engine is now natively handling it](https://www.postgresql.org/docs/11/ddl-alter.html#DDL-ALTER-ADDING-A-COLUMN).
+
+Beware though, when adding a volatile default value: 
+```ruby
+add_column :users, :created_at, default: 'clock_timestamp()'
+```
+PG will still needs to update every row of the table, and will most likely statement timeout for big table. In this case, your best bet is to add the column without default, set the default, and backfill existing rows.
+
 ### Concurrent indexes
 
 Creating an index requires a `SHARE` lock on the target table which blocks all write on the table while the index is created (which can take some time on a large table). This is usually not practical in a live environment. Thus, **Safe PG Migrations** ensures indexes are created concurrently.
 
+As `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` are non-blocking operations (ie: read/write operations on the table are still possible), **Safe PG Migrations** sets a lock timeout to 30 seconds for those 2 specific statements.
+
+If you still get lock timeout while adding / removing indexes, it might be for one of those reasons:
+
+- Long-running queries are active on the table. To create / remove an index, PG needs to wait for the queries that are actually running to finish before starting the index creation / removal. The blocking activity logger might help you to pinpoint the culprit queries.
+- A vacuum / autovacuum is running on the table, holding a ShareUpdateExclusiveLock, you are most likely out of luck for the current migration, but you may try to [optimize your autovacuums settings](https://www.percona.com/blog/2018/08/10/tuning-autovacuum-in-postgresql-and-autovacuum-internals/).
+
+
 ### Retry after lock timeout
 
-When a statement fails with a lock timeout, **Safe PG Migrations** retries them (5 times max).
+When a statement fails with a lock timeout, **Safe PG Migrations** retries it (5 times max) [list of retryable statments](https://github.com/doctolib/safe-pg-migrations/blob/66933256252b6bbf12e404b829a361dbba30e684/lib/safe-pg-migrations/plugins/statement_retrier.rb#L5)
 
 ### Blocking activity logging
 
 If a statement fails with a lock timeout, **Safe PG Migrations** will try to tell you what was the blocking statement.
+
+### Verbose SQL logging
+
+For any operation, **Safe PG Migrations** can output the performed SQL queries. This feature is enabled by default in a production Rails environment. If you want to explicit enable it, for example in your development environment you can use:
+```bash
+export SAFE_PG_MIGRATIONS_VERBOSE=1
+```
+
+Instead of the traditional output:
+```ruby
+add_index :users, :age
+
+== 20191215132355 SampleIndex: migrating ======================================
+-- add_index(:users, :age)
+   -> add_index("users", :age, {:algorithm=>:concurrently})
+   -> 0.0175s
+== 20191215132355 SampleIndex: migrated (0.0200s) =============================
+```
+**Sage PG Migrations** will output the following logs:
+```ruby
+add_index :users, :age
+
+== 20191215132355 SampleIndex: migrating ======================================
+   (0.3ms)  SHOW lock_timeout
+   (0.3ms)  SET lock_timeout TO '5s'
+-- add_index(:users, :age)
+   -> add_index("users", :age, {:algorithm=>:concurrently})
+   (0.3ms)  SHOW statement_timeout
+   (0.3ms)  SET statement_timeout TO 0
+   (0.3ms)  SHOW lock_timeout
+   (0.3ms)  SET lock_timeout TO '30s'
+   (3.5ms)  CREATE INDEX CONCURRENTLY "index_users_on_age" ON "users"  ("age")
+   (0.3ms)  SET lock_timeout TO '5s'
+   (0.2ms)  SET statement_timeout TO '1min'
+   -> 0.0093s
+   (0.2ms)  SET lock_timeout TO '0'
+== 20191215132355 SampleIndex: migrated (0.0114s) =============================
+```
+So you can actually check that the `CREATE INDEX` statement will be performed concurrently, without any statement timeout and with a lock timeout of 30 seconds.
+
+*Nb: The `SHOW` statements are used by **Safe PG Migrations** to query settings for their original values in order to restore them after the work is done*
+
+## Configuration
+
+**Safe PG Migrations** can be customized, here is an example of a Rails initializer (the values are the default ones):
+
+```ruby
+SafePgMigrations.config.safe_timeout = 5.seconds # Lock and statement timeout used for all DDL operations except from CREATE / DROP INDEX
+
+SafePgMigrations.config.index_lock_timeout = 30.seconds # Lock timeout used for CREATE / DROP INDEX
+
+SafePgMigrations.config.blocking_activity_logger_margin = 1.second # Delay to output blocking queries before timeout. Must be smaller than safe_timeout and index_lock_timeout
+
+SafePgMigrations.config.batch_size = 1000 # Size of the batches used for backfilling when adding a column with a default value pre-PG11
+
+SafePgMigrations.config.retry_delay = 1.minute # Delay between retries for retryable statements
+
+SafePgMigrations.config.max_tries = 5 # Number of retries before abortion of the migration
+```
 
 ## Runnings tests
 
@@ -149,6 +228,5 @@ Interesting reads:
 - [Adding a NOT NULL CONSTRAINT on PG Faster with Minimal Locking](https://medium.com/doctolib-engineering/adding-a-not-null-constraint-on-pg-faster-with-minimal-locking-38b2c00c4d1c)
 - [Adding columns with default values to really large tables in Postgres + Rails](https://wework.github.io/data/2015/11/05/add-columns-with-default-values-to-large-tables-in-rails-postgres/)
 - [Rails migrations with no downtime](https://pedro.herokuapp.com/past/2011/7/13/rails_migrations_with_no_downtime/)
-- [
-Safe Operations For High Volume PostgreSQL](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)
+- [Safe Operations For High Volume PostgreSQL](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)
 - [Rails Migrations with Zero Downtime](https://blog.codeship.com/rails-migrations-zero-downtime/)

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -5,17 +5,32 @@ require 'active_support/core_ext/numeric/time'
 module SafePgMigrations
   class Configuration
     attr_accessor :safe_timeout
-    attr_accessor :blocking_activity_logger_delay # Must be close to but smaller than safe_timeout.
+    attr_accessor :index_lock_timeout
+    attr_accessor :blocking_activity_logger_margin
     attr_accessor :batch_size
     attr_accessor :retry_delay
     attr_accessor :max_tries
 
     def initialize
-      self.safe_timeout = '5s'
-      self.blocking_activity_logger_delay = 4.seconds
+      self.safe_timeout = 5.seconds
+      self.index_lock_timeout = 30.seconds
+      self.blocking_activity_logger_margin = 1.second
       self.batch_size = 1000
-      self.retry_delay = 2.minutes
+      self.retry_delay = 1.minute
       self.max_tries = 5
+    end
+
+    def pg_safe_timeout
+      pg_duration(safe_timeout)
+    end
+
+    def pg_index_lock_timeout
+      pg_duration(index_lock_timeout)
+    end
+
+    def pg_duration(duration)
+      value, unit = duration.integer? ? [duration, 's'] : [(duration * 1000).to_i, 'ms']
+      "#{value}#{unit}"
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/verbose_sql_logger.rb
+++ b/lib/safe-pg-migrations/plugins/verbose_sql_logger.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  class VerboseSqlLogger
+    def setup
+      @activerecord_logger_was = ActiveRecord::Base.logger
+      @verbose_query_logs_was = ActiveRecord::Base.verbose_query_logs
+      @colorize_logging_was = ActiveRecord::LogSubscriber.colorize_logging
+
+      disable_marginalia if defined?(Marginalia)
+
+      stdout_logger = Logger.new($stdout, formatter: ->(_severity, _time, _progname, query) { "#{query}\n" })
+      ActiveRecord::Base.logger = stdout_logger
+      ActiveRecord::LogSubscriber.colorize_logging = colorize_logging?
+      # Do not output caller method, we know it is coming from the migration
+      ActiveRecord::Base.verbose_query_logs = false
+      self
+    end
+
+    def teardown
+      ActiveRecord::Base.verbose_query_logs = @verbose_query_logs_was
+      ActiveRecord::LogSubscriber.colorize_logging = @colorize_logging_was
+      ActiveRecord::Base.logger = @activerecord_logger_was
+      enable_marginalia if defined?(Marginalia)
+    end
+
+    private
+
+    def colorize_logging?
+      defined?(Rails) && Rails.env.development?
+    end
+
+    # Marginalia annotations will most likely pollute the output
+    def disable_marginalia
+      @marginalia_components_were = Marginalia::Comment.components
+      Marginalia::Comment.components = []
+    end
+
+    def enable_marginalia
+      Marginalia::Comment.components = @marginalia_components_were
+    end
+  end
+end

--- a/lib/safe-pg-migrations/railtie.rb
+++ b/lib/safe-pg-migrations/railtie.rb
@@ -4,7 +4,7 @@ require 'safe-pg-migrations/base'
 
 module SafePgMigrations
   class Railtie < Rails::Railtie
-    initializer 'sage_pg_migrations.insert_into_active_record' do
+    initializer 'safe_pg_migrations.insert_into_active_record' do
       ActiveSupport.on_load :active_record do
         ActiveRecord::Migration.prepend(SafePgMigrations::Migration)
       end

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -92,7 +92,7 @@ class SafePgMigrationsTest < Minitest::Test
       '   -> ',
       '   -> Retrying in 1 seconds...',
       '   -> Retrying now.',
-    ], calls[6..8]
+    ], calls[7..9]
   end
 
   def test_retry_if_lock_timeout

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -7,7 +7,6 @@ class SafePgMigrationsTest < Minitest::Test
 
   def setup
     SafePgMigrations.instance_variable_set(:@config, nil)
-    SafePgMigrations.enabled = true
     @connection = ActiveRecord::Base.connection
     @verbose_was = ActiveRecord::Migration.verbose
     @connection.create_table(:schema_migrations) { |t| t.string :version }
@@ -20,12 +19,12 @@ class SafePgMigrationsTest < Minitest::Test
   def teardown
     ActiveRecord::SchemaMigration.drop_table
     @connection.execute('SET statement_timeout TO 0')
-    @connection.execute('SET lock_timeout TO 0')
+    @connection.execute("SET lock_timeout TO '30s'")
     @connection.drop_table(:users, if_exists: true)
     ActiveRecord::Migration.verbose = @verbose_was
   end
 
-  def test_transaction_disabling
+  def test_remove_transaction
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
         class << self
@@ -40,26 +39,16 @@ class SafePgMigrationsTest < Minitest::Test
         end
       end.new
 
-    SafePgMigrations.enabled = false
-    run_migration
-    assert @connection.table_exists?(:users)
-    assert_equal(
-      true,
-      @migration.class.did_open_transaction,
-      'Migrations are executed inside a transaction when SafePgMigrations is disabled'
-    )
-
-    run_migration(:down)
-    refute @connection.table_exists?(:users)
-
-    SafePgMigrations.enabled = true
     run_migration
     assert @connection.table_exists?(:users)
     assert_equal(
       false,
       @migration.class.did_open_transaction,
-      'Migrations are not executed inside a transaction when SafePgMigrations is enabled'
+      'Migrations are not executed inside a transaction with SafePgMigrations'
     )
+
+    run_migration(:down)
+    refute @connection.table_exists?(:users)
   end
 
   def test_statement_retry
@@ -86,8 +75,8 @@ class SafePgMigrationsTest < Minitest::Test
       end.new
 
     SafePgMigrations.config.retry_delay = 1.second
-    SafePgMigrations.config.safe_timeout = '500ms'
-    SafePgMigrations.config.blocking_activity_logger_delay = 0.1.seconds
+    SafePgMigrations.config.safe_timeout = 0.5.second
+    SafePgMigrations.config.blocking_activity_logger_margin = 0.1.seconds
 
     calls = record_calls(@migration, :write) { run_migration }.map(&:first)
     assert @connection.column_exists?(:users, :email, :string)
@@ -128,14 +117,14 @@ class SafePgMigrationsTest < Minitest::Test
         end
       end
     assert_equal [
-      '   -> Retrying in 120 seconds...',
+      '   -> Retrying in 60 seconds...',
       '   -> Retrying now.',
-      '   -> Retrying in 120 seconds...',
+      '   -> Retrying in 60 seconds...',
       '   -> Retrying now.',
     ], calls[1..4].map(&:first)
   end
 
-  def test_add_column
+  def test_add_column_before_pg_11
     @connection.create_table(:users)
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -170,6 +159,40 @@ class SafePgMigrationsTest < Minitest::Test
       '   -> backfill_column_default("users", :admin)',
       '   -> change_column_null("users", :admin, false)',
     ], write_calls.map(&:first)[0...-3]
+  end
+
+  def test_add_column_after_pg_11
+    @connection.create_table(:users)
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def up
+          add_column(:users, :admin, :boolean, default: false, null: false)
+        end
+      end.new
+
+    SafePgMigrations.stub(:get_pg_version_num, 110_000) do
+      execute_calls = nil
+      write_calls =
+        record_calls(@migration, :write) do
+          execute_calls = record_calls(@connection, :execute) { run_migration }
+        end
+      assert_calls [
+        # The column is added with the default without any trick
+        'ALTER TABLE "users" ADD "admin" boolean DEFAULT FALSE',
+
+        # The not-null constraint is added.
+        "SET statement_timeout TO '5s'",
+        'ALTER TABLE "users" ALTER "admin" SET NOT NULL',
+        "SET statement_timeout TO '70s'",
+      ], execute_calls
+
+      assert_equal [
+        '== 8128 : migrating ===========================================================',
+        '-- add_column(:users, :admin, :boolean, {:default=>false, :null=>false})',
+        '   -> add_column("users", :admin, :boolean, {:default=>false})',
+        '   -> change_column_null("users", :admin, false)',
+      ], write_calls.map(&:first)[0...-3]
+    end
   end
 
   def test_remove_column_idem_potent
@@ -246,7 +269,9 @@ class SafePgMigrationsTest < Minitest::Test
 
       # An index is created because of the column reference.
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
     ], calls
 
@@ -276,7 +301,9 @@ class SafePgMigrationsTest < Minitest::Test
 
       # Create the index.
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '5s'",
 
       "SET statement_timeout TO '70s'",
@@ -298,16 +325,14 @@ class SafePgMigrationsTest < Minitest::Test
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
     ], calls
 
     run_migration(:down)
     refute @connection.index_exists?(:users, :email)
-
-    SafePgMigrations.enabled = false
-    calls = record_calls(@connection, :execute) { run_migration }
-    assert_equal 'CREATE INDEX "index_users_on_email" ON "users" ("email")', calls[3][0].squish
   end
 
   def test_add_index_idem_potent
@@ -323,9 +348,13 @@ class SafePgMigrationsTest < Minitest::Test
 
     assert_calls [
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'CREATE INDEX CONCURRENTLY "my_custom_index_name" ON "users" ("email") WHERE email IS NOT NULL',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
     ], calls
   end
@@ -344,10 +373,16 @@ class SafePgMigrationsTest < Minitest::Test
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
+
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'DROP INDEX CONCURRENTLY "index_users_on_email"',
+      "SET lock_timeout TO '30s'",
       "SET statement_timeout TO '0'",
+
       'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
     ], calls
   end
@@ -368,7 +403,9 @@ class SafePgMigrationsTest < Minitest::Test
 
       # The index is created concurrently.
       'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
       'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
+      "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '70s'",
 
       # The foreign key is added.
@@ -406,6 +443,7 @@ class SafePgMigrationsTest < Minitest::Test
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
         disable_ddl_transaction!
+
         def up
           transaction do
             with_setting(:statement_timeout, '1s') do
@@ -421,6 +459,27 @@ class SafePgMigrationsTest < Minitest::Test
     rescue StandardError => e
       assert_instance_of ActiveRecord::StatementInvalid, e.cause
       assert_includes e.cause.message, 'boom!'
+    end
+  end
+
+  def test_verbose_sql_logging
+    SafePgMigrations.stub(:verbose?, true) do
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def up
+            execute('SELECT * from pg_stat_activity')
+            execute('SELECT version()')
+          end
+        end.new
+
+      stdout, _stderr = capture_io { run_migration }
+      logs = stdout.split("\n").map(&:strip)
+
+      assert_match('SHOW lock_timeout', logs[0])
+      assert_match("SET lock_timeout TO '5s'", logs[1])
+      assert_match('SELECT * from pg_stat_activity', logs[2])
+      assert_match('SELECT version()', logs[3])
+      assert_match("SET lock_timeout TO '70s'", logs[4])
     end
   end
 


### PR DESCRIPTION
Hey !

# Added features
## Support PG 11
As PG 11 handle `add_column` with a default non-volatile value gracefully, we do not need the backfill trick anymore.

## Raise lock timeout for CREATE / DROP INDEX CONCURRENTLY
Most of our index creations on large tables in the last months were unsuccessful because of a lock timeout. As the only way to create indexes with **Safe PG Migrations** is concurrently, being locked for more than `5s` does not harm, so we increased it to `30s`.

## Add a way to log every SQL query to stdout
To demystify **Safe PG Migrations** inner working, and to better investigate migration failure in production, we added a way to log every SQL query happening in a migration. This is also useful in development to get a better grasp of what is going on for high-level statements like `add_reference`

## Remove the `enabled` config value
A user would expect the gem to do not anything when disabled. But it was more of a `wrap_in_transaction` setting, and it made the `add_index` operation dangerous, as it **forced** a statement_timeout to 0.
As we saw no clear gain in maintaining this setting VS just moving the gem to the appropriate env in our Gemfile, we decided to drop it. Plus having the same issues in development could be a good start to understand what's going to happen in production and how to fix it

## MISC
- improve README
- normalize configuration types, was needed to dynamically configure the blocking query logger sleep delay

Some breaking changes, I don't really know our policy on backward compatibility though