### PR TITLE
Fixing travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 services:
   - postgresql
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
 
 before_script:
   - psql -c 'CREATE DATABASE safe_pg_migrations_test' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ cache: bundler
 rvm:
   - 2.3
   - 2.5
+services:
+  - postgresql
 addons:
-  postgresql: 9.3
+  postgresql: "9.3"
 
 before_script:
   - psql -c 'CREATE DATABASE safe_pg_migrations_test' -U postgres

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -10,7 +10,7 @@ module SafePgMigrations
       end
     end
 
-    def add_column(table_name, column_name, type, **options)
+    def add_column(table_name, column_name, type, **options) # rubocop:disable Metrics/CyclomaticComplexity
       need_default_value_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
 
       default = options.delete(:default) if need_default_value_backfill

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -373,9 +373,9 @@ class SafePgMigrationsTest < Minitest::Test
     calls = record_calls(@connection, :execute) { run_migration }
 
     assert_calls [
-     "SET statement_timeout TO '5s'",
-     'ALTER TABLE "users" ALTER COLUMN "email" TYPE text',
-     "SET statement_timeout TO '70s'",
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "users" ALTER COLUMN "email" TYPE text',
+      "SET statement_timeout TO '70s'",
     ], calls
   end
 


### PR DESCRIPTION
Travis was broken because psql 9.4 (that we used) is no longer supported by travis. This PR: 
* Uses psql 9.6 in travis (9.4 is no longer supported neither by travis nor APT, I haven't looked further)
* Fixes some rubocop
* Skips rubocop for the add_column method (I'll create a ticket for that)