### PR TITLE
Add duration for blocking queries

### DIFF
--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -75,7 +75,7 @@ module SafePgMigrations
           "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
         )
         SafePgMigrations.say '', true
-        queries.each { |query, start_time| SafePgMigrations.say "  #{query} [#{format_start_time start_time}]", true }
+        queries.each { |query, start_time| SafePgMigrations.say "  #{query} -- [#{format_start_time start_time}]", true }
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
           'located elsewhere in the transaction',

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -75,7 +75,7 @@ module SafePgMigrations
           "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
         )
         SafePgMigrations.say '', true
-        queries.each { |query, start_time| SafePgMigrations.say "  #{query} -- [#{format_start_time start_time}]", true }
+        queries.each { |query, start_time| SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true }
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
           'located elsewhere in the transaction',
@@ -89,7 +89,7 @@ module SafePgMigrations
 
     def format_start_time(start_time, reference_time = Time.now)
       duration = (reference_time - start_time).round
-      "started at #{start_time}, #{duration} #{'second'.pluralize(duration)} ago"
+      "transaction started #{duration} #{'second'.pluralize(duration)} ago"
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -3,7 +3,7 @@
 module SafePgMigrations
   module BlockingActivityLogger
     SELECT_BLOCKING_QUERIES_SQL = <<~SQL.squish
-      SELECT blocking_activity.query
+      SELECT blocking_activity.query, blocked_activity.xact_start as start
       FROM pg_catalog.pg_locks           blocked_locks
       JOIN pg_catalog.pg_stat_activity   blocked_activity
         ON blocked_activity.pid = blocked_locks.pid
@@ -50,7 +50,7 @@ module SafePgMigrations
       blocking_queries_retriever_thread =
         Thread.new do
           sleep delay_before_logging(method)
-          SafePgMigrations.alternate_connection.query_values(SELECT_BLOCKING_QUERIES_SQL % raw_connection.backend_pid)
+          SafePgMigrations.alternate_connection.query(SELECT_BLOCKING_QUERIES_SQL % raw_connection.backend_pid)
         end
 
       yield
@@ -75,7 +75,7 @@ module SafePgMigrations
           "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
         )
         SafePgMigrations.say '', true
-        queries.each { |query| SafePgMigrations.say "  #{query}", true }
+        queries.each { |query, start_time| SafePgMigrations.say "  #{query} [#{format_start_time start_time}]", true }
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
           'located elsewhere in the transaction',
@@ -85,6 +85,11 @@ module SafePgMigrations
       end
 
       raise
+    end
+
+    def format_start_time(start_time, reference_time = Time.now)
+      duration = (reference_time - start_time).round
+      "started at #{start_time}, #{duration} #{'second'.pluralize(duration)} ago"
     end
   end
 end

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -85,7 +85,7 @@ class SafePgMigrationsTest < Minitest::Test
       '   -> Statement was being blocked by the following query:',
       '   -> ',
     ], calls[0..4]
-    assert_includes calls[5], '   ->   BEGIN; SELECT 1 FROM users'
+    assert_match(/   ->   BEGIN; SELECT 1 FROM users \[started at .*, 1 second ago]/, calls[5])
     assert_equal [
       '   -> ',
       '   -> Retrying in 1 seconds...',

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -85,7 +85,7 @@ class SafePgMigrationsTest < Minitest::Test
       '   -> Statement was being blocked by the following query:',
       '   -> ',
     ], calls[0..4]
-    assert_match(/   ->   BEGIN; SELECT 1 FROM users \[started at .*, 1 second ago]/, calls[5])
+    assert_match(/   ->   BEGIN; SELECT 1 FROM users \-\- \[started at .*, 1 second ago]/, calls[5])
     assert_equal [
       '   -> ',
       '   -> Retrying in 1 seconds...',

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -85,7 +85,7 @@ class SafePgMigrationsTest < Minitest::Test
       '   -> Statement was being blocked by the following query:',
       '   -> ',
     ], calls[0..4]
-    assert_match(/   ->   BEGIN; SELECT 1 FROM users \-\- \[started at .*, 1 second ago]/, calls[5])
+    assert_match(/\s*-> transaction started 1 second ago:\s*BEGIN; SELECT 1 FROM users/, calls[5])
     assert_equal [
       '   -> ',
       '   -> Retrying in 1 seconds...',


### PR DESCRIPTION
Adds the duration of a blocking query. 

The result will now look like this: 

```== 8128 : migrating ===========================================================
-- add_column(:users, :email, :string)
-> Lock timeout.
-> Statement was being blocked by the following query:
-> 
->   BEGIN; SELECT 1 FROM users -- [started at 2020-11-18 18:30:01 +0000, 1 second ago]
-> Beware, some of those queries might run in a transaction. In this case the locking query might be located elsewhere in the transaction
-> 
-> Retrying in 1 seconds...
-> Retrying now.
-> 1.5153s
== 8128 : migrated (1.5243s) ==================================================
```