### PR TITLE
Make create_table idempotent for indexes as well

### DIFF
--- a/lib/safe-pg-migrations/plugins/idem_potent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idem_potent_statements.rb
@@ -51,7 +51,7 @@ module SafePgMigrations
 
       yield td if block_given?
 
-      SafePgMigrations.say(td.indexes.empty? ? 'Skipping statement' : 'Creating indexes', true)
+      SafePgMigrations.say(td.indexes.empty? ? '-- Skipping statement' : '-- Creating indexes', true)
 
       td.indexes.each do |column_name, index_options|
         add_index(table_name, column_name, index_options)

--- a/lib/safe-pg-migrations/plugins/idem_potent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idem_potent_statements.rb
@@ -43,12 +43,19 @@ module SafePgMigrations
     end
 
     def create_table(table_name, comment: nil, **options)
-      return super unless table_exists?(table_name)
+      return super if options[:force] || !table_exists?(table_name)
 
-      SafePgMigrations.say(
-        "/!\\ Table '#{table_name}' already exists. Skipping statement.",
-        true
-      )
+      SafePgMigrations.say "/!\\ Table '#{table_name}' already exists.", true
+
+      td = create_table_definition(table_name, **options)
+
+      yield td if block_given?
+
+      SafePgMigrations.say(td.indexes.empty? ? 'Skipping statement' : 'Creating indexes', true)
+
+      td.indexes.each do |column_name, index_options|
+        add_index(table_name, column_name, index_options)
+      end
     end
 
     private

--- a/test/create_table_test.rb
+++ b/test/create_table_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SafePgMigrationsTest < Minitest::Test
+  def setup
+    SafePgMigrations.instance_variable_set(:@config, nil)
+    @connection = ActiveRecord::Base.connection
+    @verbose_was = ActiveRecord::Migration.verbose
+    @connection.create_table(:schema_migrations) { |t| t.string :version }
+    ActiveRecord::SchemaMigration.create_table
+    ActiveRecord::Migration.verbose = false
+    @connection.execute("SET statement_timeout TO '70s'")
+    @connection.execute("SET lock_timeout TO '70s'")
+  end
+
+  def teardown
+    ActiveRecord::SchemaMigration.drop_table
+    @connection.execute('SET statement_timeout TO 0')
+    @connection.execute("SET lock_timeout TO '30s'")
+    @connection.drop_table(:users, if_exists: true)
+    ActiveRecord::Migration.verbose = @verbose_was
+  end
+
+  def test_create_table
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def change
+          create_table(:users) do |t|
+            t.string :email
+            t.references :user, foreign_key: true
+          end
+        end
+      end.new
+
+    calls = record_calls(@connection, :execute) { run_migration }
+    assert_calls [
+      "SET statement_timeout TO '5s'",
+
+      # Create the table with constraints.
+      'CREATE TABLE "users" ("id" bigserial primary key, "email" character varying, "user_id" bigint, ' \
+        'CONSTRAINT "fk_rails_6d0b8b3c2f" FOREIGN KEY ("user_id") REFERENCES "users" ("id") )',
+
+      # Create the index.
+      'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
+      'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
+      "SET lock_timeout TO '5s'",
+      "SET statement_timeout TO '5s'",
+
+      "SET statement_timeout TO '70s'",
+    ], calls
+
+    run_migration(:down)
+    refute @connection.table_exists?(:users)
+  end
+
+  def test_create_table_idempotence
+    # Simulates an interruption between the table creation and the index creation
+    @connection.create_table(:users) { |t| t.string :email }
+
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def change
+          create_table(:users) do |t|
+            t.string :email, index: true
+          end
+        end
+      end.new
+
+    calls = record_calls(@connection, :execute) { run_migration }
+    indexes = ActiveRecord::Base.connection.indexes :users
+    refute_empty indexes
+    assert_equal 'index_users_on_email', indexes.first.name
+
+    assert_calls [
+      "SET statement_timeout TO '5s'",
+      'SET statement_timeout TO 0',
+      "SET lock_timeout TO '30s'",
+      'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
+      "SET lock_timeout TO '5s'",
+      "SET statement_timeout TO '5s'",
+      "SET statement_timeout TO '70s'",
+    ], calls
+  end
+end

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -209,8 +209,9 @@ class SafePgMigrationsTest < Minitest::Test
     assert_equal [
       '== 8128 : migrating ===========================================================',
       '-- create_table(:users)',
-      "   -> /!\\ Table 'users' already exists. Skipping statement.",
-    ], write_calls[0...3]
+      "   -> /!\\ Table 'users' already exists.",
+      '   -> -- Skipping statement',
+    ], write_calls[0...4]
   end
 
   def test_add_column_idem_potent

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -319,39 +319,6 @@ class SafePgMigrationsTest < Minitest::Test
     refute @connection.column_exists?(:users, :user)
   end
 
-  def test_create_table
-    @migration =
-      Class.new(ActiveRecord::Migration::Current) do
-        def change
-          create_table(:users) do |t|
-            t.string :email
-            t.references :user, foreign_key: true
-          end
-        end
-      end.new
-
-    calls = record_calls(@connection, :execute) { run_migration }
-    assert_calls [
-      "SET statement_timeout TO '5s'",
-
-      # Create the table with constraints.
-      'CREATE TABLE "users" ("id" bigserial primary key, "email" character varying, "user_id" bigint, ' \
-        'CONSTRAINT "fk_rails_6d0b8b3c2f" FOREIGN KEY ("user_id") REFERENCES "users" ("id") )',
-
-      # Create the index.
-      'SET statement_timeout TO 0',
-      "SET lock_timeout TO '30s'",
-      'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
-      "SET lock_timeout TO '5s'",
-      "SET statement_timeout TO '5s'",
-
-      "SET statement_timeout TO '70s'",
-    ], calls
-
-    run_migration(:down)
-    refute @connection.table_exists?(:users)
-  end
-
   def test_add_index
     @connection.create_table(:users) { |t| t.string :email }
     @migration =

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,11 @@ class Minitest::Test
       "SET lock_timeout TO '5s'",
       *expected,
       "SET lock_timeout TO '70s'",
-    ], actual.map(&:first).map(&:squish).reverse.drop_while { |call| %w[BEGIN COMMIT].include? call }.reverse
+    ], flat_calls(actual)
+  end
+
+  def flat_calls(calls)
+    calls.map(&:first).map(&:squish).reverse.drop_while { |call| %w[BEGIN COMMIT].include? call }.reverse
   end
 
   # Records method calls on an object. Behaves like a test spy.


### PR DESCRIPTION
When doing this migration: 

```rb
class CreateUserTable < ActiveRecord::Migration
  def change
    create_table(:users) do |t|
      t.string :email, index: true
    end
  end
end
```

`ActiveRecord` will first create the table, then create the indexes. However, if a timeout happens while creating the index, we would not detect that the table creation was not completed, as we only check for table existence. 

## Summary

* Make create_table with table idempotent
* `force` option will also recreate the table (even if it already exists)
