### PR TITLE
Not adding index concurrently if table creation

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -51,7 +51,7 @@ module SafePgMigrations
         super do |td|
           yield td if block_given?
           td.indexes.map! do |key, index_options|
-            index_options[:algorithm] ||= nil
+            index_options[:algorithm] ||= :default
             [key, index_options]
           end
         end
@@ -59,8 +59,8 @@ module SafePgMigrations
     end
 
     def add_index(table_name, column_name, **options)
-      if options.key? :algorithm
-        options.delete :algorithm unless options[:algorithm]
+      if options[:algorithm] == :default
+        options.delete :algorithm
       else
         options[:algorithm] = :concurrently
       end

--- a/test/create_table_test.rb
+++ b/test/create_table_test.rb
@@ -44,7 +44,7 @@ class SafePgMigrationsTest < Minitest::Test
       # Create the index.
       'SET statement_timeout TO 0',
       'SET lock_timeout TO 0',
-      'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
+      'CREATE INDEX "index_users_on_user_id" ON "users" ("user_id")',
       "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '5s'",
 
@@ -87,7 +87,7 @@ class SafePgMigrationsTest < Minitest::Test
       "SET statement_timeout TO '5s'",
       'SET statement_timeout TO 0',
       'SET lock_timeout TO 0',
-      'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
+      'CREATE INDEX "index_users_on_email" ON "users" ("email")',
       "SET lock_timeout TO '5s'",
       "SET statement_timeout TO '5s'",
       "SET statement_timeout TO '70s'",


### PR DESCRIPTION
Concurrently algorithm during table creation is useless and makes the migrations much longer. 