### PR TITLE
Add PgBouncer precautionary note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Just drop this line in your Gemfile:
 gem 'safe-pg-migrations'
 ```
 
+**Note: Do not run migrations via PgBouncer connection if it is configured to use transactional or statement pooling modes. You must run migrations via a direct Postgres connection, or configure PgBouncer to use session pooling mode.**
+
 ## Example
 
 Consider the following migration:


### PR DESCRIPTION
`safe-pg-migrations` make an extensive use of `SET` (with e.g.  `statement_timeout`) and `disable_ddl_transaction!`. Those two don't play well together when used via PgBouncer in transactional pooling mode.

Transactional pooling mode is the default for server-side (Postgres-side) PgBouncer installation on Heroku.

`SET statement_timeout`/`CREATE INDEX CONCURRENTLY` and reset of `statement_timeout` could run in three different server connections.  Because of `disable_ddl_transaction!`. There are two problems here:

 - unsettling `statement_timeout` has no effect on `CREATE INDEX CONCURRENTLY`'s timeout if they are executed in different server connections
 - we leave a connection hanging in PgBouncer's pool with unset `statement_timeout`

Fixes #34