### PR TITLE
Execute NOT NULL with ADD COLUMN in PG11+

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -10,7 +10,8 @@ module SafePgMigrations
       end
     end
 
-    def add_column(table_name, column_name, type, **options) # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def add_column(table_name, column_name, type, **options)
       need_default_value_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
       apply_not_null_constraint_separately = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
 
@@ -36,6 +37,7 @@ module SafePgMigrations
         change_column_null(table_name, column_name, null)
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def add_foreign_key(from_table, to_table, **options)
       validate_present = options.key? :validate

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -32,7 +32,7 @@ module SafePgMigrations
         backfill_column_default(table_name, column_name)
       end
 
-      if apply_not_null_constraint_separately && null == false # rubocop:disable Style/GuardClause
+      if null == false # rubocop:disable Style/GuardClause
         SafePgMigrations.say_method_call(:change_column_null, table_name, column_name, null)
         change_column_null(table_name, column_name, null)
       end

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -12,10 +12,10 @@ module SafePgMigrations
 
     def add_column(table_name, column_name, type, **options) # rubocop:disable Metrics/CyclomaticComplexity
       need_default_value_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
-      need_not_null_constraint_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
+      apply_not_null_constraint_separately = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
 
       default = options.delete(:default) if need_default_value_backfill
-      null = options.delete(:null) if need_not_null_constraint_backfill
+      null = options.delete(:null) if apply_not_null_constraint_separately
 
       if !default.nil? || null == false
         SafePgMigrations.say_method_call(:add_column, table_name, column_name, type, options)
@@ -31,7 +31,7 @@ module SafePgMigrations
         backfill_column_default(table_name, column_name)
       end
 
-      if null == false # rubocop:disable Style/GuardClause
+      if apply_not_null_constraint_separately && null == false # rubocop:disable Style/GuardClause
         SafePgMigrations.say_method_call(:change_column_null, table_name, column_name, null)
         change_column_null(table_name, column_name, null)
       end

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -12,9 +12,10 @@ module SafePgMigrations
 
     def add_column(table_name, column_name, type, **options) # rubocop:disable Metrics/CyclomaticComplexity
       need_default_value_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
+      need_not_null_constraint_backfill = SafePgMigrations.pg_version_num < PG_11_VERSION_NUM
 
       default = options.delete(:default) if need_default_value_backfill
-      null = options.delete(:null)
+      null = options.delete(:null) if need_not_null_constraint_backfill
 
       if !default.nil? || null == false
         SafePgMigrations.say_method_call(:add_column, table_name, column_name, type, options)

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -175,20 +175,13 @@ class SafePgMigrationsTest < Minitest::Test
           execute_calls = record_calls(@connection, :execute) { run_migration }
         end
       assert_calls [
-        # The column is added with the default without any trick
-        'ALTER TABLE "users" ADD "admin" boolean DEFAULT FALSE',
-
-        # The not-null constraint is added.
-        "SET statement_timeout TO '5s'",
-        'ALTER TABLE "users" ALTER COLUMN "admin" SET NOT NULL',
-        "SET statement_timeout TO '70s'",
+        # The column is added with the default and not null constraint without any tricks
+        'ALTER TABLE "users" ADD "admin" boolean DEFAULT FALSE NOT NULL',
       ], execute_calls
 
       assert_equal [
         '== 8128 : migrating ===========================================================',
         '-- add_column(:users, :admin, :boolean, {:default=>false, :null=>false})',
-        '   -> add_column("users", :admin, :boolean, {:default=>false})',
-        '   -> change_column_null("users", :admin, false)',
       ], write_calls.map(&:first)[0...-3]
     end
   end


### PR DESCRIPTION
One of the performance improvements in Postgres 11 was executing an `ADD COLUMN ... NOT NULL` without needing a table rewrite. This is now a safe operation in PG11+, and we can avoid adding backwards-compatible safe version with a statement timeout that can fail in some cases.

https://www.postgresql.org/docs/release/11.0/

Fixes #37.