### PR TITLE
TT-3754: New option to hide raw SQL queries in blocking queries logger. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ So you can actually check that the `CREATE INDEX` statement will be performed co
 ```ruby
 SafePgMigrations.config.safe_timeout = 5.seconds # Lock and statement timeout used for all DDL operations except from CREATE / DROP INDEX
 
+SafePgMigrations.config.blocking_activity_logger_verbose = true # Outputs the raw blocking queries on timeout. When false, outputs information about the lock instead
+
 SafePgMigrations.config.blocking_activity_logger_margin = 1.second # Delay to output blocking queries before timeout. Must be shorter than safe_timeout
 
 SafePgMigrations.config.batch_size = 1000 # Size of the batches used for backfilling when adding a column with a default value pre-PG11

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -6,6 +6,7 @@ module SafePgMigrations
   class Configuration
     attr_accessor :safe_timeout
     attr_accessor :blocking_activity_logger_margin
+    attr_accessor :blocking_activity_logger_verbose
     attr_accessor :batch_size
     attr_accessor :retry_delay
     attr_accessor :max_tries
@@ -13,6 +14,7 @@ module SafePgMigrations
     def initialize
       self.safe_timeout = 5.seconds
       self.blocking_activity_logger_margin = 1.second
+      self.blocking_activity_logger_verbose = true
       self.batch_size = 1000
       self.retry_delay = 1.minute
       self.max_tries = 5

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -2,27 +2,18 @@
 
 module SafePgMigrations
   module BlockingActivityLogger
-    SELECT_BLOCKING_QUERIES_SQL = <<~SQL.squish
-      SELECT blocking_activity.query, blocked_activity.xact_start as start
-      FROM pg_catalog.pg_locks           blocked_locks
-      JOIN pg_catalog.pg_stat_activity   blocked_activity
-        ON blocked_activity.pid = blocked_locks.pid
-      JOIN pg_catalog.pg_locks           blocking_locks
-        ON blocking_locks.locktype = blocked_locks.locktype
-        AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
-        AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
-        AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
-        AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
-        AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
-        AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-        AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
-        AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
-        AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
-        AND blocking_locks.pid != blocked_locks.pid
-      JOIN pg_catalog.pg_stat_activity   blocking_activity
-        ON blocking_activity.pid = blocking_locks.pid
-      WHERE blocked_locks.pid = %d
-    SQL
+    FILTERED_COLUMNS = %w(
+      blocked_activity.xact_start
+      blocked_locks.locktype
+      blocked_locks.mode
+      blocking_activity.pid
+      blocked_locks.transactionid
+    ).freeze
+
+    VERBOSE_COLUMNS = %w(
+      blocking_activity.query
+      blocked_activity.xact_start
+    ).freeze
 
     %i[
       add_column remove_column add_foreign_key remove_foreign_key change_column_default change_column_null create_table
@@ -34,6 +25,32 @@ module SafePgMigrations
 
     private
 
+    def select_blocking_queries_sql
+      columns = SafePgMigrations.config.blocking_activity_logger_verbose ? VERBOSE_COLUMNS : FILTERED_COLUMNS
+
+      <<~SQL.squish
+        SELECT #{columns.join(', ')}
+        FROM pg_catalog.pg_locks           blocked_locks
+        JOIN pg_catalog.pg_stat_activity   blocked_activity
+          ON blocked_activity.pid = blocked_locks.pid
+        JOIN pg_catalog.pg_locks           blocking_locks
+          ON blocking_locks.locktype = blocked_locks.locktype
+          AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
+          AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
+          AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
+          AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
+          AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
+          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+          AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
+          AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
+          AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
+          AND blocking_locks.pid != blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity   blocking_activity
+          ON blocking_activity.pid = blocking_locks.pid
+        WHERE blocked_locks.pid = %d
+      SQL
+    end
+
     def log_blocking_queries
       delay_before_logging =
         SafePgMigrations.config.safe_timeout - SafePgMigrations.config.blocking_activity_logger_margin
@@ -41,7 +58,7 @@ module SafePgMigrations
       blocking_queries_retriever_thread =
         Thread.new do
           sleep delay_before_logging
-          SafePgMigrations.alternate_connection.query(SELECT_BLOCKING_QUERIES_SQL % raw_connection.backend_pid)
+          SafePgMigrations.alternate_connection.query(select_blocking_queries_sql % raw_connection.backend_pid)
         end
 
       yield
@@ -66,7 +83,7 @@ module SafePgMigrations
           "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
         )
         SafePgMigrations.say '', true
-        queries.each { |query, start_time| SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true }
+        output_blocking_queries(queries)
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
           'located elsewhere in the transaction',
@@ -76,6 +93,22 @@ module SafePgMigrations
       end
 
       raise
+    end
+
+    def output_blocking_queries(queries)
+      if SafePgMigrations.config.blocking_activity_logger_verbose
+        queries.each do |query, start_time|
+          SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true
+        end
+      else
+        queries.each do |start_time, locktype, mode, pid, transactionid|
+          SafePgMigrations.say format_start_time(start_time), true
+          SafePgMigrations.say "lock type: #{locktype || 'null'}"
+          SafePgMigrations.say "lock mode: #{mode || 'null'}"
+          SafePgMigrations.say "lock pid: #{pid || 'null'}"
+          SafePgMigrations.say "lock transactionid: #{transactionid || 'null'}"
+        end
+      end
     end
 
     def format_start_time(start_time, reference_time = Time.now)

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -105,7 +105,7 @@ module SafePgMigrations
               "lock mode: #{mode || 'null'}, " \
               "lock pid: #{pid || 'null'}, " \
               "lock transactionid: #{transactionid || 'null'}",
-            true,
+            true
           )
         end
       end

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -79,7 +79,10 @@ module SafePgMigrations
       if queries.empty?
         SafePgMigrations.say 'Could not find any blocking query.', true
       else
-
+        SafePgMigrations.say(
+          "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
+        )
+        SafePgMigrations.say '', true
         output_blocking_queries(queries)
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
@@ -94,20 +97,16 @@ module SafePgMigrations
 
     def output_blocking_queries(queries)
       if SafePgMigrations.config.blocking_activity_logger_verbose
-        SafePgMigrations.say(
-          "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
-        )
-        SafePgMigrations.say '', true
-        queries.each do |query, start_time|
-          SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true
-        end
+        queries.each { |query, start_time| SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true }
       else
         queries.each do |start_time, locktype, mode, pid, transactionid|
-          SafePgMigrations.say format_start_time(start_time), true
-          SafePgMigrations.say "lock type: #{locktype || 'null'}", true
-          SafePgMigrations.say "lock mode: #{mode || 'null'}", true
-          SafePgMigrations.say "lock pid: #{pid || 'null'}", true
-          SafePgMigrations.say "lock transactionid: #{transactionid || 'null'}", true
+          SafePgMigrations.say(
+            "#{format_start_time(start_time)}: lock type: #{locktype || 'null'}, " \
+              "lock mode: #{mode || 'null'}, " \
+              "lock pid: #{pid || 'null'}, " \
+              "lock transactionid: #{transactionid || 'null'}",
+            true,
+          )
         end
       end
     end

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -2,18 +2,18 @@
 
 module SafePgMigrations
   module BlockingActivityLogger
-    FILTERED_COLUMNS = %w(
+    FILTERED_COLUMNS = %w[
       blocked_activity.xact_start
       blocked_locks.locktype
       blocked_locks.mode
       blocking_activity.pid
       blocked_locks.transactionid
-    ).freeze
+    ].freeze
 
-    VERBOSE_COLUMNS = %w(
+    VERBOSE_COLUMNS = %w[
       blocking_activity.query
       blocked_activity.xact_start
-    ).freeze
+    ].freeze
 
     %i[
       add_column remove_column add_foreign_key remove_foreign_key change_column_default change_column_null create_table

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -79,10 +79,7 @@ module SafePgMigrations
       if queries.empty?
         SafePgMigrations.say 'Could not find any blocking query.', true
       else
-        SafePgMigrations.say(
-          "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
-        )
-        SafePgMigrations.say '', true
+
         output_blocking_queries(queries)
         SafePgMigrations.say(
           'Beware, some of those queries might run in a transaction. In this case the locking query might be '\
@@ -97,16 +94,20 @@ module SafePgMigrations
 
     def output_blocking_queries(queries)
       if SafePgMigrations.config.blocking_activity_logger_verbose
+        SafePgMigrations.say(
+          "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
+        )
+        SafePgMigrations.say '', true
         queries.each do |query, start_time|
           SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true
         end
       else
         queries.each do |start_time, locktype, mode, pid, transactionid|
           SafePgMigrations.say format_start_time(start_time), true
-          SafePgMigrations.say "lock type: #{locktype || 'null'}"
-          SafePgMigrations.say "lock mode: #{mode || 'null'}"
-          SafePgMigrations.say "lock pid: #{pid || 'null'}"
-          SafePgMigrations.say "lock transactionid: #{transactionid || 'null'}"
+          SafePgMigrations.say "lock type: #{locktype || 'null'}", true
+          SafePgMigrations.say "lock mode: #{mode || 'null'}", true
+          SafePgMigrations.say "lock pid: #{pid || 'null'}", true
+          SafePgMigrations.say "lock transactionid: #{transactionid || 'null'}", true
         end
       end
     end

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -60,7 +60,6 @@ class SafePgMigrationsTest < Minitest::Test
     assert_includes calls, 'lock mode: AccessExclusiveLock'
     assert_includes calls, 'lock pid:'
     assert_includes calls, 'lock transactionid: null'
-    refute_includes calls, 'Statement was being blocked by the following query'
   end
 
   def test_statement_retry

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -588,14 +588,14 @@ class SafePgMigrationsTest < Minitest::Test
   end
 
   private
-  
+
   def simulate_blocking_transaction_from_another_connection
     SafePgMigrations.config.retry_delay = 1.second
     SafePgMigrations.config.safe_timeout = 0.5.second
     SafePgMigrations.config.blocking_activity_logger_margin = 0.1.seconds
 
     @connection.create_table(:users)
-    
+
     Class.new(ActiveRecord::Migration::Current) do
       def up
         thread_lock = Concurrent::CountDownLatch.new


### PR DESCRIPTION
Implements the possibility to prevent blocking queries form being logged & instead display informations about the lock itself, in order to avoid potentially displaying private user informations