### PR TITLE
Rename Idem Potent to Idempotent

### DIFF
--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -6,14 +6,14 @@ require 'safe-pg-migrations/plugins/verbose_sql_logger'
 require 'safe-pg-migrations/plugins/blocking_activity_logger'
 require 'safe-pg-migrations/plugins/statement_insurer'
 require 'safe-pg-migrations/plugins/statement_retrier'
-require 'safe-pg-migrations/plugins/idem_potent_statements'
+require 'safe-pg-migrations/plugins/idempotent_statements'
 require 'safe-pg-migrations/plugins/useless_statements_logger'
 
 module SafePgMigrations
   # Order matters: the bottom-most plugin will have precedence
   PLUGINS = [
     BlockingActivityLogger,
-    IdemPotentStatements,
+    IdempotentStatements,
     StatementRetrier,
     StatementInsurer,
     UselessStatementsLogger,

--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SafePgMigrations
-  module IdemPotentStatements
+  module IdempotentStatements
     ruby2_keywords def add_index(table_name, column_name, *args)
       options = args.last.is_a?(Hash) ? args.last : {}
       index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, index_column_names(column_name))

--- a/test/add_foreign_key_test.rb
+++ b/test/add_foreign_key_test.rb
@@ -105,7 +105,7 @@ class AddForeignKeyTest < MiniTest::Test
     ], calls
   end
 
-  def test_add_foreign_key_idem_potent
+  def test_add_foreign_key_idempotent
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:messages) do |t|
       t.string :message
@@ -147,7 +147,7 @@ class AddForeignKeyTest < MiniTest::Test
     ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
-  def test_add_foreign_key_idem_potent_with_column_option
+  def test_add_foreign_key_idempotent_with_column_option
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:messages) do |t|
       t.string :message
@@ -190,7 +190,7 @@ class AddForeignKeyTest < MiniTest::Test
     ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
-  def test_add_foreign_key_idem_potent_with_other_options
+  def test_add_foreign_key_idempotent_with_other_options
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:messages) do |t|
       t.string :message
@@ -234,7 +234,7 @@ class AddForeignKeyTest < MiniTest::Test
     ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
-  def test_add_foreign_key_idem_potent_different_tables
+  def test_add_foreign_key_idempotent_different_tables
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:conversations) { |t| t.string :subject }
     @connection.create_table(:messages) do |t|

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -268,7 +268,7 @@ class SafePgMigrationsTest < Minitest::Test
     end
   end
 
-  def test_create_table_idem_potent
+  def test_create_table_idempotent
     @connection.create_table(:users) { |t| t.string :email }
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -289,7 +289,7 @@ class SafePgMigrationsTest < Minitest::Test
     ], write_calls[0...4]
   end
 
-  def test_add_column_idem_potent
+  def test_add_column_idempotent
     @connection.create_table(:users) { |t| t.string :email }
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -310,7 +310,7 @@ class SafePgMigrationsTest < Minitest::Test
     ], write_calls[3..4]
   end
 
-  def test_remove_column_idem_potent
+  def test_remove_column_idempotent
     @connection.create_table(:users) { |t| t.string :email, index: true }
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -336,7 +336,7 @@ class SafePgMigrationsTest < Minitest::Test
     refute @connection.index_exists?(:users, :email)
   end
 
-  def test_remove_index_idem_potent
+  def test_remove_index_idempotent
     @connection.create_table(:users) { |t| t.string(:email, index: true) }
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -417,7 +417,7 @@ class SafePgMigrationsTest < Minitest::Test
     refute @connection.index_exists?(:users, :email)
   end
 
-  def test_add_index_idem_potent
+  def test_add_index_idempotent
     @connection.create_table(:users) { |t| t.string :email }
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
@@ -459,7 +459,7 @@ class SafePgMigrationsTest < Minitest::Test
     ], calls
   end
 
-  def test_add_index_idem_potent_invalid_index
+  def test_add_index_idempotent_invalid_index
     @connection.create_table(:users) { |t| t.string :email, index: true }
 
     @migration =


### PR DESCRIPTION
It's more commonly used as a single English word
https://en.wiktionary.org/wiki/idempotent rather than two Latin words.