### PR TITLE
Fix support for ActiveRecord < 6

### DIFF
--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -8,7 +8,7 @@ require 'safe-pg-migrations/plugins/statement_insurer'
 require 'safe-pg-migrations/plugins/statement_retrier'
 require 'safe-pg-migrations/plugins/idempotent_statements'
 require 'safe-pg-migrations/plugins/useless_statements_logger'
-require 'safe-pg-migrations/plugins/old_rails_version_support'
+require 'safe-pg-migrations/plugins/legacy_active_record_support'
 
 module SafePgMigrations
   # Order matters: the bottom-most plugin will have precedence
@@ -18,7 +18,7 @@ module SafePgMigrations
     StatementRetrier,
     StatementInsurer,
     UselessStatementsLogger,
-    OldRailsVersionSupport,
+    LegacyActiveRecordSupport,
   ].freeze
 
   class << self

--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -8,6 +8,7 @@ require 'safe-pg-migrations/plugins/statement_insurer'
 require 'safe-pg-migrations/plugins/statement_retrier'
 require 'safe-pg-migrations/plugins/idempotent_statements'
 require 'safe-pg-migrations/plugins/useless_statements_logger'
+require 'safe-pg-migrations/plugins/old_rails_version_support'
 
 module SafePgMigrations
   # Order matters: the bottom-most plugin will have precedence
@@ -17,6 +18,7 @@ module SafePgMigrations
     StatementRetrier,
     StatementInsurer,
     UselessStatementsLogger,
+    OldRailsVersionSupport,
   ].freeze
 
   class << self

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -2,22 +2,22 @@
 
 module SafePgMigrations
   module LegacyActiveRecordSupport
-    ACTIVE_RECORD_VERSION = ActiveRecord::VERSION::STRING
-
     ruby2_keywords def validate_foreign_key(from_table, to_table = nil, **options)
-      if ACTIVE_RECORD_VERSION < '6'
-        super(from_table, to_table || options)
-      else
-        super(from_table, to_table, **options)
-      end
+      return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
+
+      super(from_table, to_table, **options)
     end
 
     ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, **options)
-      if ACTIVE_RECORD_VERSION < '6'
-        super(from_table, to_table || options)
-      else
-        super(from_table, to_table, **options)
-      end
+      return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
+
+      super(from_table, to_table, **options)
+    end
+
+    private
+
+    def satisfied?(version)
+      Gem::Requirement.new(version).satisfied_by? Gem::Version.new(::ActiveRecord::VERSION::STRING)
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SafePgMigrations
-  module OldRailsVersionSupport
+  module LegacyActiveRecordSupport
     ACTIVE_RECORD_VERSION = ActiveRecord::VERSION::STRING
 
     ruby2_keywords def validate_foreign_key(from_table, to_table = nil, **options)

--- a/lib/safe-pg-migrations/plugins/old_rails_version_support.rb
+++ b/lib/safe-pg-migrations/plugins/old_rails_version_support.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  module OldRailsVersionSupport
+    ACTIVE_RECORD_VERSION = ActiveRecord::VERSION::STRING
+
+    ruby2_keywords def validate_foreign_key(from_table, to_table = nil, **options)
+      if ACTIVE_RECORD_VERSION < '6'
+        super(from_table, to_table || options)
+      else
+        super(from_table, to_table, **options)
+      end
+    end
+
+    ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, **options)
+      if ACTIVE_RECORD_VERSION < '6'
+        super(from_table, to_table || options)
+      else
+        super(*args, **options)
+      end
+    end
+  end
+end

--- a/lib/safe-pg-migrations/plugins/old_rails_version_support.rb
+++ b/lib/safe-pg-migrations/plugins/old_rails_version_support.rb
@@ -16,7 +16,7 @@ module SafePgMigrations
       if ACTIVE_RECORD_VERSION < '6'
         super(from_table, to_table || options)
       else
-        super(*args, **options)
+        super(from_table, to_table, **options)
       end
     end
   end

--- a/test/add_foreign_key_test.rb
+++ b/test/add_foreign_key_test.rb
@@ -42,11 +42,11 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-    ], calls
+                   "SET statement_timeout TO '70s'",
+                 ], calls
   end
 
   def test_add_foreign_key
@@ -65,14 +65,14 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-      "SET statement_timeout TO '70s'",
-    ], calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+                   "SET statement_timeout TO '70s'",
+                 ], calls
   end
 
   def test_add_foreign_key_with_options
@@ -95,14 +95,14 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "message_user_key" FOREIGN KEY ("author_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "message_user_key" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("real_id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "message_user_key"',
-      "SET statement_timeout TO '70s'",
-    ], calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "message_user_key"',
+                   "SET statement_timeout TO '70s'",
+                 ], calls
   end
 
   def test_add_foreign_key_idempotent
@@ -125,26 +125,26 @@ class AddForeignKeyTest < Minitest::Test
         execute_calls = record_calls(@connection, :execute) { run_migration }
       end
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-      "SET statement_timeout TO '70s'",
-      "SET statement_timeout TO '5s'",
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-      "SET statement_timeout TO '70s'",
-    ], execute_calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+                   "SET statement_timeout TO '70s'",
+                   "SET statement_timeout TO '5s'",
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+                   "SET statement_timeout TO '70s'",
+                 ], execute_calls
 
     assert_equal [
-      '== 8128 : migrating ===========================================================',
-      '-- add_foreign_key(:messages, :users)',
-      '-- add_foreign_key(:messages, :users)',
-      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+                   '== 8128 : migrating ===========================================================',
+                   '-- add_foreign_key(:messages, :users)',
+                   '-- add_foreign_key(:messages, :users)',
+                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_with_column_option
@@ -168,26 +168,26 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-      "SET statement_timeout TO '70s'",
-      "SET statement_timeout TO '5s'",
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-      "SET statement_timeout TO '70s'",
-    ], execute_calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+                   "SET statement_timeout TO '70s'",
+                   "SET statement_timeout TO '5s'",
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+                   "SET statement_timeout TO '70s'",
+                 ], execute_calls
 
     assert_equal [
-      '== 8128 : migrating ===========================================================',
-      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+                   '== 8128 : migrating ===========================================================',
+                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_with_other_options
@@ -212,26 +212,26 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-      "SET statement_timeout TO '70s'",
-      "SET statement_timeout TO '5s'",
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-      "SET statement_timeout TO '70s'",
-    ], execute_calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+                   "SET statement_timeout TO '70s'",
+                   "SET statement_timeout TO '5s'",
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+                   "SET statement_timeout TO '70s'",
+                 ], execute_calls
 
     assert_equal [
-      '== 8128 : migrating ===========================================================',
-      '-- add_foreign_key(:messages, :users)',
-      '-- add_foreign_key(:messages, :users, {:on_delete=>:cascade})',
-      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+                   '== 8128 : migrating ===========================================================',
+                   '-- add_foreign_key(:messages, :users)',
+                   '-- add_foreign_key(:messages, :users, {:on_delete=>:cascade})',
+                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_different_tables
@@ -258,27 +258,27 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-      "SET statement_timeout TO '70s'",
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_7f927086d2" FOREIGN KEY ("conversation_id") ' \
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+                   "SET statement_timeout TO '70s'",
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_7f927086d2" FOREIGN KEY ("conversation_id") ' \
       'REFERENCES "conversations" ("id") NOT VALID',
-      "SET statement_timeout TO '70s'",
-      'SET statement_timeout TO 0',
-      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_7f927086d2"',
-      "SET statement_timeout TO '70s'",
-    ], execute_calls
+                   "SET statement_timeout TO '70s'",
+                   'SET statement_timeout TO 0',
+                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_7f927086d2"',
+                   "SET statement_timeout TO '70s'",
+                 ], execute_calls
 
     assert_equal [
-      '== 8128 : migrating ===========================================================',
-      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-      '-- add_foreign_key(:messages, :conversations)',
-    ], write_calls.map(&:first).values_at(0, 1, 3)
+                   '== 8128 : migrating ===========================================================',
+                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+                   '-- add_foreign_key(:messages, :conversations)',
+                 ], write_calls.map(&:first).values_at(0, 1, 3)
   end
 
   def test_add_foreign_key_with_validation
@@ -297,9 +297,23 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-      "SET statement_timeout TO '5s'",
-      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") REFERENCES "users" ("id")',
-      "SET statement_timeout TO '70s'",
-    ], calls
+                   "SET statement_timeout TO '5s'",
+                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") REFERENCES "users" ("id")',
+                   "SET statement_timeout TO '70s'",
+                 ], calls
+  end
+
+  def test_add_reference
+    @connection.create_table(:users) { |t| t.string :email }
+    @connection.create_table(:messages) { |t| t.string :message }
+
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def change
+          add_reference(:reviews, :restaurant, foreign_key: true)
+        end
+      end.new
+
+    record_calls(@connection, :execute) { run_migration }
   end
 end

--- a/test/add_foreign_key_test.rb
+++ b/test/add_foreign_key_test.rb
@@ -14,6 +14,10 @@ class AddForeignKeyTest < Minitest::Test
     ActiveRecord::Migration.verbose = false
     @connection.execute("SET statement_timeout TO '70s'")
     @connection.execute("SET lock_timeout TO '70s'")
+
+    @connection.drop_table(:messages, if_exists: true)
+    @connection.drop_table(:conversations, if_exists: true)
+    @connection.drop_table(:users, if_exists: true)
   end
 
   def teardown
@@ -310,7 +314,7 @@ class AddForeignKeyTest < Minitest::Test
     @migration =
       Class.new(ActiveRecord::Migration::Current) do
         def change
-          add_reference(:reviews, :restaurant, foreign_key: true)
+          add_reference(:messages, :user, foreign_key: true)
         end
       end.new
 

--- a/test/add_foreign_key_test.rb
+++ b/test/add_foreign_key_test.rb
@@ -46,11 +46,11 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                 ], calls
+      "SET statement_timeout TO '70s'",
+    ], calls
   end
 
   def test_add_foreign_key
@@ -69,14 +69,14 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-                   "SET statement_timeout TO '70s'",
-                 ], calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+      "SET statement_timeout TO '70s'",
+    ], calls
   end
 
   def test_add_foreign_key_with_options
@@ -99,14 +99,14 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "message_user_key" FOREIGN KEY ("author_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "message_user_key" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("real_id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "message_user_key"',
-                   "SET statement_timeout TO '70s'",
-                 ], calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "message_user_key"',
+      "SET statement_timeout TO '70s'",
+    ], calls
   end
 
   def test_add_foreign_key_idempotent
@@ -129,26 +129,26 @@ class AddForeignKeyTest < Minitest::Test
         execute_calls = record_calls(@connection, :execute) { run_migration }
       end
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-                   "SET statement_timeout TO '70s'",
-                   "SET statement_timeout TO '5s'",
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-                   "SET statement_timeout TO '70s'",
-                 ], execute_calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+      "SET statement_timeout TO '70s'",
+      "SET statement_timeout TO '5s'",
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+      "SET statement_timeout TO '70s'",
+    ], execute_calls
 
     assert_equal [
-                   '== 8128 : migrating ===========================================================',
-                   '-- add_foreign_key(:messages, :users)',
-                   '-- add_foreign_key(:messages, :users)',
-                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+      '== 8128 : migrating ===========================================================',
+      '-- add_foreign_key(:messages, :users)',
+      '-- add_foreign_key(:messages, :users)',
+      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_with_column_option
@@ -172,26 +172,26 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-                   "SET statement_timeout TO '70s'",
-                   "SET statement_timeout TO '5s'",
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-                   "SET statement_timeout TO '70s'",
-                 ], execute_calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+      "SET statement_timeout TO '70s'",
+      "SET statement_timeout TO '5s'",
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+      "SET statement_timeout TO '70s'",
+    ], execute_calls
 
     assert_equal [
-                   '== 8128 : migrating ===========================================================',
-                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+      '== 8128 : migrating ===========================================================',
+      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_with_other_options
@@ -216,26 +216,26 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-                   "SET statement_timeout TO '70s'",
-                   "SET statement_timeout TO '5s'",
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
-                   "SET statement_timeout TO '70s'",
-                 ], execute_calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+      "SET statement_timeout TO '70s'",
+      "SET statement_timeout TO '5s'",
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_273a25a7a6"',
+      "SET statement_timeout TO '70s'",
+    ], execute_calls
 
     assert_equal [
-                   '== 8128 : migrating ===========================================================',
-                   '-- add_foreign_key(:messages, :users)',
-                   '-- add_foreign_key(:messages, :users, {:on_delete=>:cascade})',
-                   "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
-                 ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+      '== 8128 : migrating ===========================================================',
+      '-- add_foreign_key(:messages, :users)',
+      '-- add_foreign_key(:messages, :users, {:on_delete=>:cascade})',
+      "   -> /!\\ Foreign key 'messages' -> 'users' already exists. Skipping statement.",
+    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
 
   def test_add_foreign_key_idempotent_different_tables
@@ -262,27 +262,27 @@ class AddForeignKeyTest < Minitest::Test
       end
 
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_995937c106" FOREIGN KEY ("author_id") ' \
       'REFERENCES "users" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
-                   "SET statement_timeout TO '70s'",
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_7f927086d2" FOREIGN KEY ("conversation_id") ' \
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_995937c106"',
+      "SET statement_timeout TO '70s'",
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_7f927086d2" FOREIGN KEY ("conversation_id") ' \
       'REFERENCES "conversations" ("id") NOT VALID',
-                   "SET statement_timeout TO '70s'",
-                   'SET statement_timeout TO 0',
-                   'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_7f927086d2"',
-                   "SET statement_timeout TO '70s'",
-                 ], execute_calls
+      "SET statement_timeout TO '70s'",
+      'SET statement_timeout TO 0',
+      'ALTER TABLE "messages" VALIDATE CONSTRAINT "fk_rails_7f927086d2"',
+      "SET statement_timeout TO '70s'",
+    ], execute_calls
 
     assert_equal [
-                   '== 8128 : migrating ===========================================================',
-                   '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
-                   '-- add_foreign_key(:messages, :conversations)',
-                 ], write_calls.map(&:first).values_at(0, 1, 3)
+      '== 8128 : migrating ===========================================================',
+      '-- add_foreign_key(:messages, :users, {:column=>:author_id})',
+      '-- add_foreign_key(:messages, :conversations)',
+    ], write_calls.map(&:first).values_at(0, 1, 3)
   end
 
   def test_add_foreign_key_with_validation
@@ -301,10 +301,10 @@ class AddForeignKeyTest < Minitest::Test
 
     calls = record_calls(@connection, :execute) { run_migration }
     assert_calls [
-                   "SET statement_timeout TO '5s'",
-                   'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") REFERENCES "users" ("id")',
-                   "SET statement_timeout TO '70s'",
-                 ], calls
+      "SET statement_timeout TO '5s'",
+      'ALTER TABLE "messages" ADD CONSTRAINT "fk_rails_273a25a7a6" FOREIGN KEY ("user_id") REFERENCES "users" ("id")',
+      "SET statement_timeout TO '70s'",
+    ], calls
   end
 
   def test_add_reference


### PR DESCRIPTION
Some methods have changed the number or argument between version 5.2 and version 6: 

`foreign_key_exists?` from

```rb
      def foreign_key_exists?(from_table, options_or_to_table = {})
```
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1010

to 
```rb
      def foreign_key_exists?(from_table, to_table = nil, **options)
```
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1151

And `validate_foreign_key` from 

```rb
        def validate_foreign_key(from_table, options_or_to_table = {})
```
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L626

To

```rb
        def validate_foreign_key(from_table, to_table = nil, **options)
```
https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L603

--- 

This fixes #59 . 