### PR TITLE
Fix ruby2_keywords flag warning

### DIFF
--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -2,16 +2,16 @@
 
 module SafePgMigrations
   module LegacyActiveRecordSupport
-    ruby2_keywords def validate_foreign_key(from_table, to_table = nil, **options)
+    ruby2_keywords def validate_foreign_key(from_table, to_table = nil, *options)
       return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
 
-      super(from_table, to_table, **options)
+      super(from_table, to_table, *options)
     end
 
-    ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, **options)
+    ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, *options)
       return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
 
-      super(from_table, to_table, **options)
+      super(from_table, to_table, *options)
     end
 
     private


### PR DESCRIPTION
Hi there! Using Ruby 2.7.4, the following warnings pop up since these methods are using keywords instead of splats:

```
/Users/sunny/code/safe-pg-migrations/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb:5: warning: Skipping set of ruby2_keywords flag for validate_foreign_key (method accepts keywords or method does not accept argument splat)
/Users/sunny/code/safe-pg-migrations/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb:11: warning: Skipping set of ruby2_keywords flag for foreign_key_exists? (method accepts keywords or method does not accept argument splat)
```