### PR TITLE
[BUGFIX] Fix compatibility with Rails < 6.1

### DIFF
--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -5,7 +5,7 @@ module SafePgMigrations
     ruby2_keywords def add_index(table_name, column_name, *args)
       options = args.last.is_a?(Hash) ? args.last : {}
 
-      index_definition, = add_index_options(table_name, column_name, **options)
+      index_definition = index_definition(table_name, column_name, **options)
 
       return super unless index_name_exists?(index_definition.table, index_definition.name)
 
@@ -68,6 +68,13 @@ module SafePgMigrations
       td.indexes.each do |column_name, index_options|
         add_index(table_name, column_name, **index_options)
       end
+    end
+
+    protected
+
+    def index_definition(table_name, column_name, **options)
+      index_definition, = add_index_options(table_name, column_name, **options)
+      index_definition
     end
 
     private

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -14,6 +14,19 @@ module SafePgMigrations
       super(from_table, to_table, **options)
     end
 
+    protected
+
+    IndexDefinition = Struct.new(:table, :name)
+
+    def index_definition(table_name, column_name, **options)
+      return super(table_name, column_name, **options) if satisfied? '>=6.1.0'
+
+      index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, index_column_names(column_name))
+      validate_index_length!(table_name, index_name, options.fetch(:internal, false))
+
+      IndexDefinition.new(table_name, index_name)
+    end
+
     private
 
     def satisfied?(version)


### PR DESCRIPTION
IndexDefinition, that we rely on for `idempotent_statement#add_index` was introduced in Rails 6.1.

This PR adds compatibility with older versions. 

Fixing #71 