### PR TITLE
Revert "Fix ruby2_keywords flag warning"

### DIFF
--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -2,16 +2,16 @@
 
 module SafePgMigrations
   module LegacyActiveRecordSupport
-    ruby2_keywords def validate_foreign_key(from_table, to_table = nil, *options)
+    ruby2_keywords def validate_foreign_key(from_table, to_table = nil, **options)
       return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
 
-      super(from_table, to_table, *options)
+      super(from_table, to_table, **options)
     end
 
-    ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, *options)
+    ruby2_keywords def foreign_key_exists?(from_table, to_table = nil, **options)
       return super(from_table, to_table || options) unless satisfied? '>=6.0.0'
 
-      super(from_table, to_table, *options)
+      super(from_table, to_table, **options)
     end
 
     protected


### PR DESCRIPTION
Reverts doctolib/safe-pg-migrations#70

Broken compatibility with activerecord 5.2 and ruby 2.6

https://github.com/doctolib/safe-pg-migrations/runs/5374516778