### PR TITLE
Add remove_foreign_key idempotent

### DIFF
--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -9,16 +9,18 @@ require 'safe-pg-migrations/plugins/statement_retrier'
 require 'safe-pg-migrations/plugins/idempotent_statements'
 require 'safe-pg-migrations/plugins/useless_statements_logger'
 require 'safe-pg-migrations/plugins/legacy_active_record_support'
+require 'safe-pg-migrations/plugins/index_definition_polyfill'
 
 module SafePgMigrations
   # Order matters: the bottom-most plugin will have precedence
   PLUGINS = [
+    LegacyActiveRecordSupport,
     BlockingActivityLogger,
     IdempotentStatements,
     StatementRetrier,
     StatementInsurer,
     UselessStatementsLogger,
-    LegacyActiveRecordSupport,
+    IndexDefinitionPolyfill,
   ].freeze
 
   class << self

--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -56,8 +56,9 @@ module SafePgMigrations
     ruby2_keywords def remove_foreign_key(from_table, to_table = nil, **options)
       return super if foreign_key_exists?(from_table, to_table, **options)
 
+      reference_name = to_table || options[:to_table] || options[:column] || options[:name]
       SafePgMigrations.say(
-        "/!\\ Foreign key '#{from_table}' -> '#{to_table || options[:to_table]}' does not exist. Skipping statement.",
+        "/!\\ Foreign key '#{from_table}' -> '#{reference_name}' does not exist. Skipping statement.",
         true
       )
     end

--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -53,6 +53,17 @@ module SafePgMigrations
       )
     end
 
+    ruby2_keywords def remove_foreign_key(from_table, to_table, *args)
+      options = args.last.is_a?(Hash) ? args.last : {}
+      suboptions = options.slice(:name, :column, :to_table)
+      return super if foreign_key_exists?(from_table, suboptions.present? ? nil : to_table, **suboptions)
+
+      SafePgMigrations.say(
+        "/!\\ Foreign key '#{from_table}' -> '#{to_table}' does not exist. Skipping statement.",
+        true
+      )
+    end
+
     ruby2_keywords def create_table(table_name, *args)
       options = args.last.is_a?(Hash) ? args.last : {}
       return super if options[:force] || !table_exists?(table_name)

--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -53,13 +53,11 @@ module SafePgMigrations
       )
     end
 
-    ruby2_keywords def remove_foreign_key(from_table, to_table, *args)
-      options = args.last.is_a?(Hash) ? args.last : {}
-      suboptions = options.slice(:name, :column, :to_table)
-      return super if foreign_key_exists?(from_table, suboptions.present? ? nil : to_table, **suboptions)
+    ruby2_keywords def remove_foreign_key(from_table, to_table = nil, **options)
+      return super if foreign_key_exists?(from_table, to_table, **options)
 
       SafePgMigrations.say(
-        "/!\\ Foreign key '#{from_table}' -> '#{to_table}' does not exist. Skipping statement.",
+        "/!\\ Foreign key '#{from_table}' -> '#{to_table || options[:to_table]}' does not exist. Skipping statement.",
         true
       )
     end

--- a/lib/safe-pg-migrations/plugins/index_definition_polyfill.rb
+++ b/lib/safe-pg-migrations/plugins/index_definition_polyfill.rb
@@ -20,6 +20,5 @@ module SafePgMigrations
     def satisfied?(version)
       Gem::Requirement.new(version).satisfied_by? Gem::Version.new(::ActiveRecord::VERSION::STRING)
     end
-
   end
 end

--- a/lib/safe-pg-migrations/plugins/index_definition_polyfill.rb
+++ b/lib/safe-pg-migrations/plugins/index_definition_polyfill.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  module IndexDefinitionPolyfill
+    protected
+
+    IndexDefinition = Struct.new(:table, :name)
+
+    def index_definition(table_name, column_name, **options)
+      return super(table_name, column_name, **options) if satisfied? '>=6.1.0'
+
+      index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, index_column_names(column_name))
+      validate_index_length!(table_name, index_name, options.fetch(:internal, false))
+
+      IndexDefinition.new(table_name, index_name)
+    end
+
+    private
+
+    def satisfied?(version)
+      Gem::Requirement.new(version).satisfied_by? Gem::Version.new(::ActiveRecord::VERSION::STRING)
+    end
+
+  end
+end

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -24,7 +24,7 @@ module SafePgMigrations
       options ||= args.last.is_a?(Hash) ? args.last : {}
       to_table ||= options[:to_table]
       options.delete(:to_table)
-      super(from_table, to_table, options)
+      super(from_table, to_table || options)
     end
 
     protected

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -27,19 +27,6 @@ module SafePgMigrations
       super(from_table, to_table || options)
     end
 
-    protected
-
-    IndexDefinition = Struct.new(:table, :name)
-
-    def index_definition(table_name, column_name, **options)
-      return super(table_name, column_name, **options) if satisfied? '>=6.1.0'
-
-      index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, index_column_names(column_name))
-      validate_index_length!(table_name, index_name, options.fetch(:internal, false))
-
-      IndexDefinition.new(table_name, index_name)
-    end
-
     private
 
     def satisfied?(version)

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -16,6 +16,15 @@ module SafePgMigrations
       super(from_table, to_table || options)
     end
 
+    ruby2_keywords def remove_foreign_key(*args)
+      return super(*args) if satisfied? '>=6.0.0'
+
+      from_table, to_table, options = args
+      to_table ||= args[:to_table]
+      options.delete(:to_table)
+      super(from_table, to_table, options)
+    end
+
     protected
 
     IndexDefinition = Struct.new(:table, :name)

--- a/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
+++ b/lib/safe-pg-migrations/plugins/legacy_active_record_support.rb
@@ -19,8 +19,10 @@ module SafePgMigrations
     ruby2_keywords def remove_foreign_key(*args)
       return super(*args) if satisfied? '>=6.0.0'
 
-      from_table, to_table, options = args
-      to_table ||= args[:to_table]
+      from_table = args[0]
+      to_table = args[1].is_a?(String) ? args[1] : nil
+      options ||= args.last.is_a?(Hash) ? args.last : {}
+      to_table ||= options[:to_table]
       options.delete(:to_table)
       super(from_table, to_table, options)
     end

--- a/test/idempotent_statements_test.rb
+++ b/test/idempotent_statements_test.rb
@@ -501,7 +501,7 @@ class IdempotentStatementsTest < Minitest::Test
         execute_calls = record_calls(@connection, :execute) { run_migration }
       end
 
-    assert_match /ALTER TABLE "messages" DROP CONSTRAINT "fk_rails_\w*"/, flat_calls(execute_calls)[1]
+    assert_match(/ALTER TABLE "messages" DROP CONSTRAINT "fk_rails_\w*"/, flat_calls(execute_calls)[1])
 
     assert_equal [
       '== 8128 : migrating ===========================================================',

--- a/test/idempotent_statements_test.rb
+++ b/test/idempotent_statements_test.rb
@@ -412,7 +412,6 @@ class IdempotentStatementsTest < Minitest::Test
     ], calls
   end
 
-
   def test_remove_foreign_key
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:messages) do |t|

--- a/test/idempotent_statements_test.rb
+++ b/test/idempotent_statements_test.rb
@@ -446,6 +446,10 @@ class IdempotentStatementsTest < Minitest::Test
   end
 
   def test_remove_foreign_key_using_to_table
+    if Gem::Requirement.new('<6.0.0').satisfied_by?(Gem::Version.new(::ActiveRecord::VERSION::STRING))
+      skip 'Not available for AR < 6.0'
+    end
+
     @connection.create_table(:users) { |t| t.string :email }
     @connection.create_table(:messages) do |t|
       t.string :message

--- a/test/idempotent_statements_test.rb
+++ b/test/idempotent_statements_test.rb
@@ -433,7 +433,6 @@ class IdempotentStatementsTest < Minitest::Test
         execute_calls = record_calls(@connection, :execute) { run_migration }
       end
 
-    puts execute_calls
     assert_calls [
       'ALTER TABLE "messages" DROP CONSTRAINT "fk_rails_e3b11c0cbb"',
     ], execute_calls

--- a/test/idempotent_statements_test.rb
+++ b/test/idempotent_statements_test.rb
@@ -479,4 +479,68 @@ class IdempotentStatementsTest < Minitest::Test
       "   -> /!\\ Foreign key 'messages' -> 'users' does not exist. Skipping statement.",
     ], write_calls.map(&:first).values_at(0, 1, 3, 4)
   end
+
+  def test_remove_foreign_key_using_column
+    @connection.create_table(:users) { |t| t.string :email }
+    @connection.create_table(:messages) do |t|
+      t.string :message
+      t.bigint :author_id
+    end
+    @connection.add_foreign_key :messages, :users, column: :author_id
+
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def change
+          2.times { remove_foreign_key :messages, column: :author_id }
+        end
+      end.new
+
+    execute_calls = nil
+    write_calls =
+      record_calls(@migration, :write) do
+        execute_calls = record_calls(@connection, :execute) { run_migration }
+      end
+
+    assert_match /ALTER TABLE "messages" DROP CONSTRAINT "fk_rails_\w*"/, flat_calls(execute_calls)[1]
+
+    assert_equal [
+      '== 8128 : migrating ===========================================================',
+      '-- remove_foreign_key(:messages, {:column=>:author_id})',
+      '-- remove_foreign_key(:messages, {:column=>:author_id})',
+      "   -> /!\\ Foreign key 'messages' -> 'author_id' does not exist. Skipping statement.",
+    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+  end
+
+  def test_remove_foreign_key_using_foreign_key_name
+    @connection.create_table(:users) { |t| t.string :email }
+    @connection.create_table(:messages) do |t|
+      t.string :message
+      t.bigint :user_id
+    end
+    @connection.add_foreign_key :messages, :users, name: :special_fk_name
+
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def change
+          2.times { remove_foreign_key :messages, name: :special_fk_name }
+        end
+      end.new
+
+    execute_calls = nil
+    write_calls =
+      record_calls(@migration, :write) do
+        execute_calls = record_calls(@connection, :execute) { run_migration }
+      end
+
+    assert_calls [
+      'ALTER TABLE "messages" DROP CONSTRAINT "special_fk_name"',
+    ], execute_calls
+
+    assert_equal [
+      '== 8128 : migrating ===========================================================',
+      '-- remove_foreign_key(:messages, {:name=>:special_fk_name})',
+      '-- remove_foreign_key(:messages, {:name=>:special_fk_name})',
+      "   -> /!\\ Foreign key 'messages' -> 'special_fk_name' does not exist. Skipping statement.",
+    ], write_calls.map(&:first).values_at(0, 1, 3, 4)
+  end
 end


### PR DESCRIPTION
Such a migration: 

```rb
class RemoveDocumentsFkFromInstantMessagingMessages < ActiveRecord::Migration[7.0]
  def change
    remove_foreign_key :messages, :documents
    add_foreign_key :messages, :documents, column: :prescription_id
  end
end
```
is not idempotent: if `add_foreign_key` fails, the migration cannot be run again because the foreign key on messages refering document_id is already deleted. 

A safer approach is this one:  
```rb
class RemoveDocumentsFkFromInstantMessagingMessages < ActiveRecord::Migration[7.0]
  def change
    if foreign_key_exists?(:messages, :documents)
      remove_foreign_key :messages, :documents
    end
    add_foreign_key :messages, :documents, column: :prescription_id
  end
end
```

---

safe-pg-migrations can help here, this PR is bringing idempotence to remove_foreign_key so that the first migration can be used fearlessly. 