### PR TITLE
Add logs when add_index is taking too long

### DIFF
--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -26,9 +26,8 @@ module SafePgMigrations
 
       def output_blocking_queries(queries)
         if SafePgMigrations.config.blocking_activity_logger_verbose
-          queries.each do |query, start_time|
-            SafePgMigrations.say "#{format_start_time start_time}:  #{query}",
-                                 true
+          queries.each do |pid, query, start_time|
+            SafePgMigrations.say "Query with pid #{pid || 'null'} started #{format_start_time start_time}:  #{query}", true
           end
         else
           output_confidentially_blocking_queries(queries)
@@ -38,9 +37,10 @@ module SafePgMigrations
       def output_confidentially_blocking_queries(queries)
         queries.each do |start_time, locktype, mode, pid, transactionid|
           SafePgMigrations.say(
-            "#{format_start_time(start_time)}: lock type: #{locktype || 'null'}, " \
+            "Query with pid #{pid || 'null'} " \
+            "started #{format_start_time(start_time)}: " \
+            "lock type: #{locktype || 'null'}, " \
             "lock mode: #{mode || 'null'}, " \
-            "lock pid: #{pid || 'null'}, " \
             "lock transactionid: #{transactionid || 'null'}",
             true
           )
@@ -51,7 +51,7 @@ module SafePgMigrations
         start_time = Time.parse(start_time) unless start_time.is_a? Time
 
         duration = (reference_time - start_time).round
-        "transaction started #{duration} #{'second'.pluralize(duration)} ago"
+        "#{duration} #{'second'.pluralize(duration)} ago"
       end
     end
   end

--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -27,7 +27,8 @@ module SafePgMigrations
       def output_blocking_queries(queries)
         if SafePgMigrations.config.blocking_activity_logger_verbose
           queries.each do |pid, query, start_time|
-            SafePgMigrations.say "Query with pid #{pid || 'null'} started #{format_start_time start_time}:  #{query}", true
+            SafePgMigrations.say "Query with pid #{pid || 'null'} started #{format_start_time start_time}:  #{query}",
+                                 true
           end
         else
           output_confidentially_blocking_queries(queries)

--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -49,6 +49,7 @@ module SafePgMigrations
 
       def format_start_time(start_time, reference_time = Time.now)
         start_time = Time.parse(start_time) unless start_time.is_a? Time
+
         duration = (reference_time - start_time).round
         "transaction started #{duration} #{'second'.pluralize(duration)} ago"
       end

--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -5,20 +5,20 @@ module SafePgMigrations
     module BlockingActivityFormatter
       def log_queries(queries)
         if queries.empty?
-          SafePgMigrations.say "Could not find any blocking query.", true
+          SafePgMigrations.say 'Could not find any blocking query.', true
         else
           SafePgMigrations.say(
-            "Statement was being blocked by the following #{"query".pluralize(queries.size)}:",
+            "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:",
             true
           )
-          SafePgMigrations.say "", true
+          SafePgMigrations.say '', true
           output_blocking_queries(queries)
           SafePgMigrations.say(
-            "Beware, some of those queries might run in a transaction. In this case the locking query might be " \
-              "located elsewhere in the transaction",
+            'Beware, some of those queries might run in a transaction. In this case the locking query might be ' \
+            'located elsewhere in the transaction',
             true
           )
-          SafePgMigrations.say "", true
+          SafePgMigrations.say '', true
         end
       end
 
@@ -38,10 +38,10 @@ module SafePgMigrations
       def output_confidentially_blocking_queries(queries)
         queries.each do |start_time, locktype, mode, pid, transactionid|
           SafePgMigrations.say(
-            "#{format_start_time(start_time)}: lock type: #{locktype || "null"}, " \
-              "lock mode: #{mode || "null"}, " \
-              "lock pid: #{pid || "null"}, " \
-              "lock transactionid: #{transactionid || "null"}",
+            "#{format_start_time(start_time)}: lock type: #{locktype || 'null'}, " \
+            "lock mode: #{mode || 'null'}, " \
+            "lock pid: #{pid || 'null'}, " \
+            "lock transactionid: #{transactionid || 'null'}",
             true
           )
         end
@@ -50,7 +50,7 @@ module SafePgMigrations
       def format_start_time(start_time, reference_time = Time.now)
         start_time = Time.parse(start_time) unless start_time.is_a? Time
         duration = (reference_time - start_time).round
-        "transaction started #{duration} #{"second".pluralize(duration)} ago"
+        "transaction started #{duration} #{'second'.pluralize(duration)} ago"
       end
     end
   end

--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  module Helpers
+    module BlockingActivityFormatter
+      def log_queries(queries)
+        if queries.empty?
+          SafePgMigrations.say "Could not find any blocking query.", true
+        else
+          SafePgMigrations.say(
+            "Statement was being blocked by the following #{"query".pluralize(queries.size)}:",
+            true
+          )
+          SafePgMigrations.say "", true
+          output_blocking_queries(queries)
+          SafePgMigrations.say(
+            "Beware, some of those queries might run in a transaction. In this case the locking query might be " \
+              "located elsewhere in the transaction",
+            true
+          )
+          SafePgMigrations.say "", true
+        end
+      end
+
+      private
+
+      def output_blocking_queries(queries)
+        if SafePgMigrations.config.blocking_activity_logger_verbose
+          queries.each do |query, start_time|
+            SafePgMigrations.say "#{format_start_time start_time}:  #{query}",
+                                 true
+          end
+        else
+          output_confidentially_blocking_queries(queries)
+        end
+      end
+
+      def output_confidentially_blocking_queries(queries)
+        queries.each do |start_time, locktype, mode, pid, transactionid|
+          SafePgMigrations.say(
+            "#{format_start_time(start_time)}: lock type: #{locktype || "null"}, " \
+              "lock mode: #{mode || "null"}, " \
+              "lock pid: #{pid || "null"}, " \
+              "lock transactionid: #{transactionid || "null"}",
+            true
+          )
+        end
+      end
+
+      def format_start_time(start_time, reference_time = Time.now)
+        start_time = Time.parse(start_time) unless start_time.is_a? Time
+        duration = (reference_time - start_time).round
+        "transaction started #{duration} #{"second".pluralize(duration)} ago"
+      end
+    end
+  end
+end

--- a/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  module Helpers
+    module BlockingActivitySelector
+      FILTERED_COLUMNS = %w[
+        blocked_activity.xact_start
+        blocked_locks.locktype
+        blocked_locks.mode
+        blocking_activity.pid
+        blocked_locks.transactionid
+      ].freeze
+
+      VERBOSE_COLUMNS = %w[
+        blocking_activity.query
+        blocked_activity.xact_start
+      ].freeze
+
+      def select_blocking_queries_sql
+        columns =
+          (
+            if SafePgMigrations.config.blocking_activity_logger_verbose
+              VERBOSE_COLUMNS
+            else
+              FILTERED_COLUMNS
+            end
+          )
+
+        <<~SQL.squish
+        SELECT #{columns.join(", ")}
+        FROM pg_catalog.pg_locks           blocked_locks
+        JOIN pg_catalog.pg_stat_activity   blocked_activity
+          ON blocked_activity.pid = blocked_locks.pid
+        JOIN pg_catalog.pg_locks           blocking_locks
+          ON blocking_locks.locktype = blocked_locks.locktype
+          AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
+          AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
+          AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
+          AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
+          AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
+          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+          AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
+          AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
+          AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
+          AND blocking_locks.pid != blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity   blocking_activity
+          ON blocking_activity.pid = blocking_locks.pid
+        WHERE blocked_locks.pid = %d
+        SQL
+      end
+    end
+  end
+end

--- a/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
@@ -12,6 +12,7 @@ module SafePgMigrations
       ].freeze
 
       VERBOSE_COLUMNS = %w[
+        blocking_activity.pid
         blocking_activity.query
         blocked_activity.xact_start
       ].freeze

--- a/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_selector.rb
@@ -27,25 +27,25 @@ module SafePgMigrations
           )
 
         <<~SQL.squish
-        SELECT #{columns.join(", ")}
-        FROM pg_catalog.pg_locks           blocked_locks
-        JOIN pg_catalog.pg_stat_activity   blocked_activity
-          ON blocked_activity.pid = blocked_locks.pid
-        JOIN pg_catalog.pg_locks           blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
-          AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
-          AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
-          AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
-          AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
-          AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
-          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-          AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
-          AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
-          AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity   blocking_activity
-          ON blocking_activity.pid = blocking_locks.pid
-        WHERE blocked_locks.pid = %d
+          SELECT #{columns.join(', ')}
+          FROM pg_catalog.pg_locks           blocked_locks
+          JOIN pg_catalog.pg_stat_activity   blocked_activity
+            ON blocked_activity.pid = blocked_locks.pid
+          JOIN pg_catalog.pg_locks           blocking_locks
+            ON blocking_locks.locktype = blocked_locks.locktype
+            AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
+            AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
+            AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
+            AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
+            AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
+            AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+            AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
+            AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
+            AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
+            AND blocking_locks.pid != blocked_locks.pid
+          JOIN pg_catalog.pg_stat_activity   blocking_activity
+            ON blocking_activity.pid = blocking_locks.pid
+          WHERE blocked_locks.pid = %d
         SQL
       end
     end

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -23,10 +23,13 @@ module SafePgMigrations
       ruby2_keywords method
     end
 
-    def add_index(*args, **options)
-      return super if options[:algorithm] != :concurrently
+    %i[add_index remove_index].each do |method|
+      define_method method do |*args, **options, &block|
+        return super(*args, **options, &block) if options[:algorithm] != :concurrently
 
-      log_blocking_queries_loop { super }
+        log_blocking_queries_loop { super(*args, **options, &block) }
+      end
+      ruby2_keywords method
     end
 
     private

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -1,22 +1,21 @@
 # frozen_string_literal: true
 
-module SafePgMigrations
-  module BlockingActivityLogger # rubocop:disable Metrics/ModuleLength
-    FILTERED_COLUMNS = %w[
-      blocked_activity.xact_start
-      blocked_locks.locktype
-      blocked_locks.mode
-      blocking_activity.pid
-      blocked_locks.transactionid
-    ].freeze
+require_relative "../helpers/blocking_activity_formatter"
+require_relative "../helpers/blocking_activity_selector"
 
-    VERBOSE_COLUMNS = %w[
-      blocking_activity.query
-      blocked_activity.xact_start
-    ].freeze
+module SafePgMigrations
+  module BlockingActivityLogger
+    include ::SafePgMigrations::Helpers::BlockingActivityFormatter
+    include ::SafePgMigrations::Helpers::BlockingActivitySelector
 
     %i[
-      add_column remove_column add_foreign_key remove_foreign_key change_column_default change_column_null create_table
+      add_column
+      remove_column
+      add_foreign_key
+      remove_foreign_key
+      change_column_default
+      change_column_null
+      create_table
     ].each do |method|
       define_method method do |*args, &block|
         log_blocking_queries { super(*args, &block) }
@@ -26,100 +25,38 @@ module SafePgMigrations
 
     private
 
-    def select_blocking_queries_sql
-      columns = SafePgMigrations.config.blocking_activity_logger_verbose ? VERBOSE_COLUMNS : FILTERED_COLUMNS
-
-      <<~SQL.squish
-        SELECT #{columns.join(', ')}
-        FROM pg_catalog.pg_locks           blocked_locks
-        JOIN pg_catalog.pg_stat_activity   blocked_activity
-          ON blocked_activity.pid = blocked_locks.pid
-        JOIN pg_catalog.pg_locks           blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
-          AND blocking_locks.DATABASE      IS NOT DISTINCT FROM blocked_locks.DATABASE
-          AND blocking_locks.relation      IS NOT DISTINCT FROM blocked_locks.relation
-          AND blocking_locks.page          IS NOT DISTINCT FROM blocked_locks.page
-          AND blocking_locks.tuple         IS NOT DISTINCT FROM blocked_locks.tuple
-          AND blocking_locks.virtualxid    IS NOT DISTINCT FROM blocked_locks.virtualxid
-          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-          AND blocking_locks.classid       IS NOT DISTINCT FROM blocked_locks.classid
-          AND blocking_locks.objid         IS NOT DISTINCT FROM blocked_locks.objid
-          AND blocking_locks.objsubid      IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity   blocking_activity
-          ON blocking_activity.pid = blocking_locks.pid
-        WHERE blocked_locks.pid = %d
-      SQL
-    end
-
     def log_blocking_queries
       delay_before_logging =
-        SafePgMigrations.config.safe_timeout - SafePgMigrations.config.blocking_activity_logger_margin
+        SafePgMigrations.config.safe_timeout -
+          SafePgMigrations.config.blocking_activity_logger_margin
 
       blocking_queries_retriever_thread =
         Thread.new do
           sleep delay_before_logging
-          SafePgMigrations.alternate_connection.query(select_blocking_queries_sql % raw_connection.backend_pid)
+          SafePgMigrations.alternate_connection.query(
+            select_blocking_queries_sql % raw_connection.backend_pid
+          )
         end
 
       yield
 
       blocking_queries_retriever_thread.kill
     rescue ActiveRecord::LockWaitTimeout
-      SafePgMigrations.say 'Lock timeout.', true
+      SafePgMigrations.say "Lock timeout.", true
       queries =
         begin
           blocking_queries_retriever_thread.value
         rescue StandardError => e
-          SafePgMigrations.say("Error while retrieving blocking queries: #{e}", true)
+          SafePgMigrations.say(
+            "Error while retrieving blocking queries: #{e}",
+            true
+          )
           nil
         end
 
-      raise if queries.nil?
-
-      if queries.empty?
-        SafePgMigrations.say 'Could not find any blocking query.', true
-      else
-        SafePgMigrations.say(
-          "Statement was being blocked by the following #{'query'.pluralize(queries.size)}:", true
-        )
-        SafePgMigrations.say '', true
-        output_blocking_queries(queries)
-        SafePgMigrations.say(
-          'Beware, some of those queries might run in a transaction. In this case the locking query might be ' \
-          'located elsewhere in the transaction',
-          true
-        )
-        SafePgMigrations.say '', true
-      end
+      log_queries queries unless queries.nil?
 
       raise
-    end
-
-    def output_blocking_queries(queries)
-      if SafePgMigrations.config.blocking_activity_logger_verbose
-        queries.each { |query, start_time| SafePgMigrations.say "#{format_start_time start_time}:  #{query}", true }
-      else
-        output_confidentially_blocking_queries(queries)
-      end
-    end
-
-    def output_confidentially_blocking_queries(queries)
-      queries.each do |start_time, locktype, mode, pid, transactionid|
-        SafePgMigrations.say(
-          "#{format_start_time(start_time)}: lock type: #{locktype || 'null'}, " \
-          "lock mode: #{mode || 'null'}, " \
-          "lock pid: #{pid || 'null'}, " \
-          "lock transactionid: #{transactionid || 'null'}",
-          true
-        )
-      end
-    end
-
-    def format_start_time(start_time, reference_time = Time.now)
-      start_time = Time.parse(start_time) unless start_time.is_a? Time
-      duration = (reference_time - start_time).round
-      "transaction started #{duration} #{'second'.pluralize(duration)} ago"
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -29,7 +29,6 @@ module SafePgMigrations
 
         log_blocking_queries_loop { super(*args, **options, &block) }
       end
-      ruby2_keywords method
     end
 
     private

--- a/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
+++ b/lib/safe-pg-migrations/plugins/blocking_activity_logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../helpers/blocking_activity_formatter"
-require_relative "../helpers/blocking_activity_selector"
+require_relative '../helpers/blocking_activity_formatter'
+require_relative '../helpers/blocking_activity_selector'
 
 module SafePgMigrations
   module BlockingActivityLogger
@@ -18,18 +18,37 @@ module SafePgMigrations
       create_table
     ].each do |method|
       define_method method do |*args, &block|
-        log_blocking_queries { super(*args, &block) }
+        log_blocking_queries_after_lock { super(*args, &block) }
       end
       ruby2_keywords method
     end
 
+    def add_index(*args, **options)
+      return super if options[:algorithm] != :concurrently
+
+      log_blocking_queries_loop { super }
+    end
+
     private
 
-    def log_blocking_queries
-      delay_before_logging =
-        SafePgMigrations.config.safe_timeout -
-          SafePgMigrations.config.blocking_activity_logger_margin
+    def log_blocking_queries_loop
+      blocking_queries_retriever_thread =
+        Thread.new do
+          loop do
+            sleep SafePgMigrations.config.retry_delay
 
+            log_queries SafePgMigrations.alternate_connection.query(
+              select_blocking_queries_sql % raw_connection.backend_pid
+            )
+          end
+        end
+
+      yield
+
+      blocking_queries_retriever_thread.kill
+    end
+
+    def log_blocking_queries_after_lock
       blocking_queries_retriever_thread =
         Thread.new do
           sleep delay_before_logging
@@ -42,7 +61,7 @@ module SafePgMigrations
 
       blocking_queries_retriever_thread.kill
     rescue ActiveRecord::LockWaitTimeout
-      SafePgMigrations.say "Lock timeout.", true
+      SafePgMigrations.say 'Lock timeout.', true
       queries =
         begin
           blocking_queries_retriever_thread.value
@@ -57,6 +76,15 @@ module SafePgMigrations
       log_queries queries unless queries.nil?
 
       raise
+    end
+
+    def delay_before_logging
+      SafePgMigrations.config.safe_timeout -
+        SafePgMigrations.config.blocking_activity_logger_margin
+    end
+
+    def delay_before_retry
+      SafePgMigrations.config.blocking_activity_logger_margin + SafePgMigrations.config.retry_delay
     end
   end
 end

--- a/test/blocking_activity_logger_test.rb
+++ b/test/blocking_activity_logger_test.rb
@@ -10,7 +10,7 @@ class BlockingActivityLoggerTest < Minitest::Test
 
     calls = record_calls(@migration, :write) { run_migration }.join
 
-    assert_match /Query with pid \d+ started \d seconds? ago/, calls
+    assert_match(/Query with pid \d+ started \d seconds? ago/, calls)
     assert_includes calls, 'lock type: relation'
     assert_includes calls, 'lock mode: AccessExclusiveLock'
     assert_includes calls, 'lock transactionid: null'
@@ -25,7 +25,7 @@ class BlockingActivityLoggerTest < Minitest::Test
     assert_includes calls, 'Lock timeout.'
     assert_includes calls, 'Statement was being blocked by the following query:'
 
-    assert_match /Query with pid \d+ started 1 second ago/, calls
+    assert_match(/Query with pid \d+ started 1 second ago/, calls)
     assert_includes calls, 'BEGIN; SELECT 1 FROM users'
     assert_includes calls, '   -> Retrying in 1 seconds...'
     assert_includes calls, '   -> Retrying now.'
@@ -38,10 +38,10 @@ class BlockingActivityLoggerTest < Minitest::Test
     assert_includes calls,
                     'add_index("users", :email, {:algorithm=>:concurrently})'
     assert_includes calls, 'Statement was being blocked by the following query'
-    assert_match /Query with pid \d+ started 1 second ago:  SELECT pg_sleep\(3\)/,
-                    calls
-    assert_match /Query with pid \d+ started 2 seconds ago:  SELECT pg_sleep\(3\)/,
-                    calls
+    assert_match(/Query with pid \d+ started 1 second ago:  SELECT pg_sleep\(3\)/,
+                 calls)
+    assert_match(/Query with pid \d+ started 2 seconds ago:  SELECT pg_sleep\(3\)/,
+                 calls)
 
     puts calls
   end

--- a/test/blocking_activity_logger_test.rb
+++ b/test/blocking_activity_logger_test.rb
@@ -9,9 +9,55 @@ class BlockingActivityLoggerTest < Minitest::Test
     @migration = simulate_blocking_transaction_from_another_connection
 
     calls = record_calls(@migration, :write) { run_migration }.join
+
     assert_includes calls, 'lock type: relation'
     assert_includes calls, 'lock mode: AccessExclusiveLock'
     assert_includes calls, 'lock pid:'
     assert_includes calls, 'lock transactionid: null'
+    refute_includes calls, 'BEGIN; SELECT 1 FROM users'
+  end
+
+  def test_logger_unfiltered
+    @migration = simulate_blocking_transaction_from_another_connection
+    calls = record_calls(@migration, :write) { run_migration }.join
+
+    assert_includes calls, '-- add_column(:users, :email, :string)'
+    assert_includes calls, 'Lock timeout.'
+    assert_includes calls, 'Statement was being blocked by the following query:'
+
+    assert_includes calls, 'transaction started 1 second ago'
+    assert_includes calls, 'BEGIN; SELECT 1 FROM users'
+    assert_includes calls, '   -> Retrying in 1 seconds...'
+    assert_includes calls, '   -> Retrying now.'
+  end
+
+  def test_add_index_unfiltered
+    @migration = simulate_long_running_query_from_another_transaction
+    calls = record_calls(@migration, :write) { run_migration }.join
+
+    assert_includes calls,
+                    'add_index("users", :email, {:algorithm=>:concurrently})'
+    assert_includes calls, 'Statement was being blocked by the following query'
+    assert_includes calls,
+                    'transaction started 1 second ago:  SELECT pg_sleep(3);'
+    assert_includes calls,
+                    'transaction started 2 seconds ago:  SELECT pg_sleep(3)'
+  end
+
+  def test_add_index_filtered
+    SafePgMigrations.config.blocking_activity_logger_verbose = false
+    @migration = simulate_long_running_query_from_another_transaction
+
+    calls = record_calls(@migration, :write) { run_migration }.join
+
+    assert_includes calls,
+                    'add_index("users", :email, {:algorithm=>:concurrently})'
+    assert_includes calls, 'Statement was being blocked by the following query'
+
+    variable_part_regex =
+      /lock mode: ShareLock, lock pid: \d+, lock transactionid: null/
+
+    assert_match(Regexp.union(/transaction started 1 second ago: /, variable_part_regex), calls)
+    assert_match(Regexp.union(/transaction started 2 seconds ago: /, variable_part_regex), calls)
   end
 end

--- a/test/blocking_activity_logger_test.rb
+++ b/test/blocking_activity_logger_test.rb
@@ -42,8 +42,6 @@ class BlockingActivityLoggerTest < Minitest::Test
                  calls)
     assert_match(/Query with pid \d+ started 2 seconds ago:  SELECT pg_sleep\(3\)/,
                  calls)
-
-    puts calls
   end
 
   def test_add_index_filtered

--- a/test/statement_retrier_test.rb
+++ b/test/statement_retrier_test.rb
@@ -41,7 +41,7 @@ class StatementRetrierTest < Minitest::Test
       '   -> Statement was being blocked by the following query:',
       '   -> ',
     ], calls[0..4]
-    assert_match(/\s*-> transaction started \d+ seconds? ago:\s*BEGIN; SELECT 1 FROM users/, calls[5])
+    assert_match(/\s*-> Query with pid \d+ started \d+ seconds? ago:\s*BEGIN; SELECT 1 FROM users/, calls[5])
     assert_equal [
       '   -> ',
       '   -> Retrying in 1 seconds...',

--- a/test/verbose_sql_logger_test.rb
+++ b/test/verbose_sql_logger_test.rb
@@ -17,6 +17,12 @@ class VerboseSqlLoggerTest < Minitest::Test
     super
   end
 
+  def teardown
+    ENV.delete 'SAFE_PG_MIGRATIONS_VERBOSE'
+
+    super
+  end
+
   def test_logs_in_output
     SafePgMigrations.stub(:verbose?, true) do
       stdout, _stderr = capture_io { run_migration }


### PR DESCRIPTION
Blocking activity is now compatible with add_index and remove_index, where locks are not being trigerred. 

Also includes the blocking activity PID when the verbose mode is set. 