### PR TITLE
Adding drop_table to the list of retriable statements

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -3,7 +3,7 @@
 module SafePgMigrations
   module StatementRetrier
     RETRIABLE_SCHEMA_STATEMENTS = %i[
-      add_column add_foreign_key remove_foreign_key change_column_default change_column_null remove_column
+      add_column add_foreign_key remove_foreign_key change_column_default change_column_null remove_column drop_table
     ].freeze
 
     RETRIABLE_SCHEMA_STATEMENTS.each do |method|


### PR DESCRIPTION
## context
Only a few statements are allowed to retry (up to 5 times) drop_table is not one of them.

## changes
- Added `drop_table` to the list of retriable statements

## Internal ticket
TT-17552 