### PR TITLE
Add small margin to lock timeout, otherwise it is hidden by statement timeouts

### DIFF
--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -32,7 +32,7 @@ module SafePgMigrations
       stdout_sql_logger = VerboseSqlLogger.new.setup if verbose?
       PLUGINS.each { |plugin| connection.extend(plugin) }
 
-      connection.with_setting :lock_timeout, SafePgMigrations.config.pg_safe_timeout(needs_margin: true), &block
+      connection.with_setting :lock_timeout, SafePgMigrations.config.pg_lock_timeout, &block
     ensure
       close_alternate_connection
       @current_migration = nil

--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -32,7 +32,7 @@ module SafePgMigrations
       stdout_sql_logger = VerboseSqlLogger.new.setup if verbose?
       PLUGINS.each { |plugin| connection.extend(plugin) }
 
-      connection.with_setting :lock_timeout, SafePgMigrations.config.pg_safe_timeout, &block
+      connection.with_setting :lock_timeout, SafePgMigrations.config.pg_safe_timeout(needs_margin: true), &block
     ensure
       close_alternate_connection
       @current_migration = nil

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -16,8 +16,11 @@ module SafePgMigrations
       self.max_tries = 5
     end
 
-    def pg_safe_timeout
-      pg_duration(safe_timeout)
+    def pg_safe_timeout(needs_margin: false)
+      timeout = safe_timeout
+      timeout *= 0.99 if needs_margin
+
+      pg_duration(timeout)
     end
 
     def pg_duration(duration)

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -16,12 +16,18 @@ module SafePgMigrations
       self.max_tries = 5
     end
 
-    def pg_safe_timeout(needs_margin: false)
-      timeout = safe_timeout
-      timeout *= 0.99 if needs_margin
-
-      pg_duration(timeout)
+    def pg_statement_timeout
+      pg_duration safe_timeout
     end
+
+    def pg_lock_timeout
+      # if statement timeout and lock timeout have the same value, statement timeout will raise in priority. We actually
+      # need the opposite for BlockingActivityLogger to detect lock timeouts correctly.
+      # By reducing the lock timeout by a very small margin, we ensure that the lock timeout is raised in priority
+      pg_duration safe_timeout * 0.99
+    end
+
+    private
 
     def pg_duration(duration)
       value, unit = duration.integer? ? [duration, 's'] : [(duration * 1000).to_i, 'ms']

--- a/test/IdempotentStatements/idempotent_statements_test.rb
+++ b/test/IdempotentStatements/idempotent_statements_test.rb
@@ -115,11 +115,11 @@ module IdempotentStatements
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
         'CREATE INDEX CONCURRENTLY "my_custom_index_name" ON "users" ("email") WHERE email IS NOT NULL',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '70s'",
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '70s'",
       ], calls
     end
@@ -147,7 +147,7 @@ module IdempotentStatements
         "SET statement_timeout TO '0'",
 
         'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '70s'",
       ], calls
     end
@@ -402,12 +402,12 @@ module IdempotentStatements
         "SET statement_timeout TO '5s'",
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '5s'",
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
         'CREATE INDEX "index_users_on_email" ON "users" ("email")',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '5s'",
         "SET statement_timeout TO '70s'",
       ], calls

--- a/test/StatementInsurer/statement_insurer_test.rb
+++ b/test/StatementInsurer/statement_insurer_test.rb
@@ -65,7 +65,7 @@ module StatementInsurer
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
         'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '70s'",
 
         # The foreign key is added.
@@ -203,7 +203,7 @@ module StatementInsurer
         'SET statement_timeout TO 0',
         'SET lock_timeout TO 0',
         'CREATE INDEX "index_users_on_user_id" ON "users" ("user_id")',
-        "SET lock_timeout TO '5s'",
+        "SET lock_timeout TO '4950ms'",
         "SET statement_timeout TO '5s'",
 
         "SET statement_timeout TO '70s'",

--- a/test/blocking_activity_logger_test.rb
+++ b/test/blocking_activity_logger_test.rb
@@ -25,7 +25,7 @@ class BlockingActivityLoggerTest < Minitest::Test
     assert_includes calls, 'Lock timeout.'
     assert_includes calls, 'Statement was being blocked by the following query:'
 
-    assert_match(/Query with pid \d+ started 1 second ago/, calls)
+    assert_match(/Query with pid \d+ started [01] seconds? ago/, calls)
     assert_includes calls, 'BEGIN; SELECT 1 FROM users'
     assert_includes calls, '   -> Retrying in 1 seconds...'
     assert_includes calls, '   -> Retrying now.'

--- a/test/safe_pg_migrations_test.rb
+++ b/test/safe_pg_migrations_test.rb
@@ -52,7 +52,7 @@ class SafePgMigrationsTest < Minitest::Test
       'SET statement_timeout TO 0',
       'SET lock_timeout TO 0',
       'CREATE INDEX CONCURRENTLY "index_users_on_user_id" ON "users" ("user_id")',
-      "SET lock_timeout TO '5s'",
+      "SET lock_timeout TO '4950ms'",
       "SET statement_timeout TO '70s'",
     ], calls
 
@@ -75,7 +75,7 @@ class SafePgMigrationsTest < Minitest::Test
       'SET statement_timeout TO 0',
       'SET lock_timeout TO 0',
       'CREATE INDEX CONCURRENTLY "index_users_on_email" ON "users" ("email")',
-      "SET lock_timeout TO '5s'",
+      "SET lock_timeout TO '4950ms'",
       "SET statement_timeout TO '70s'",
     ], calls
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ class Minitest::Test
 
   def assert_calls(expected, actual)
     assert_equal [
-      "SET lock_timeout TO '5s'",
+      "SET lock_timeout TO '4950ms'",
       *expected,
       "SET lock_timeout TO '70s'",
     ], flat_calls(actual)

--- a/test/verbose_sql_logger_test.rb
+++ b/test/verbose_sql_logger_test.rb
@@ -97,7 +97,7 @@ class VerboseSqlLoggerTest < Minitest::Test
     logs = stdout.split("\n").map(&:strip)
 
     assert_match('SHOW lock_timeout', logs[0])
-    assert_match("SET lock_timeout TO '5s'", logs[1])
+    assert_match("SET lock_timeout TO '4950ms'", logs[1])
     assert_match('SELECT * from pg_stat_activity', logs[2])
     assert_match('SELECT version()', logs[3])
     assert_match("SET lock_timeout TO '70s'", logs[4])


### PR DESCRIPTION
When statement timeouts and lock timeouts have the same value, statement timeout will be raised in priority. Some mechanics (blocking activity loggers for instance) rely on lock timeouts being raised. 

This fix reduces the lock timeout by 1%, so that it is raised before the statement timeout