### PR TITLE
Introduce `default_value_backfill_threshold:` config to avoid unwanted long migration when adding a column with `:update_in_batches`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :development, :test do
   gem 'pry-coolline'
   gem 'rake'
   gem 'rubocop'
+  gem 'strong_migrations'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    strong_migrations (1.4.3)
+      activerecord (>= 5.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -79,6 +81,7 @@ DEPENDENCIES
   rake
   rubocop
   safe-pg-migrations!
+  strong_migrations
 
 BUNDLED WITH
    2.2.16

--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -104,7 +104,6 @@ module SafePgMigrations
 
     SAFE_METHODS = %i[
       execute
-      add_column
       add_index
       add_reference
       add_belongs_to
@@ -120,6 +119,16 @@ module SafePgMigrations
         safety_assured { super(*args) }
       end
       ruby2_keywords method
+    end
+
+    ruby2_keywords def add_column(table_name, *args)
+      return super(table_name, *args) unless respond_to?(:safety_assured)
+
+      options = args.last.is_a?(Hash) ? args.last : {}
+
+      return safety_assured { super(table_name, *args) } if options.fetch(:default_value_backfill, :auto) == :auto
+
+      super(table_name, *args)
     end
   end
 end

--- a/lib/safe-pg-migrations/base.rb
+++ b/lib/safe-pg-migrations/base.rb
@@ -11,6 +11,7 @@ require 'safe-pg-migrations/plugins/statement_insurer'
 require 'safe-pg-migrations/plugins/statement_retrier'
 require 'safe-pg-migrations/plugins/idempotent_statements'
 require 'safe-pg-migrations/plugins/useless_statements_logger'
+require 'safe-pg-migrations/plugins/strong_migrations_integration'
 require 'safe-pg-migrations/polyfills/index_definition_polyfill'
 require 'safe-pg-migrations/polyfills/verbose_query_logs_polyfill'
 

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -5,10 +5,11 @@ require 'active_support/core_ext/numeric/time'
 module SafePgMigrations
   class Configuration
     attr_accessor :blocking_activity_logger_margin, :blocking_activity_logger_verbose,
-                  :backfill_batch_size, :backfill_pause, :retry_delay, :max_tries
+                  :backfill_batch_size_limit, :backfill_batch_size, :backfill_pause, :retry_delay, :max_tries
     attr_reader :lock_timeout, :safe_timeout
 
     def initialize
+      self.backfill_batch_size_limit = nil
       self.safe_timeout = 5.seconds
       self.lock_timeout = nil
       self.blocking_activity_logger_margin = 1.second

--- a/lib/safe-pg-migrations/plugins/statement_insurer/add_column.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer/add_column.rb
@@ -49,7 +49,8 @@ module SafePgMigrations
       def backfill_column_default_safe?(table_name)
         return true if SafePgMigrations.config.backfill_batch_size_limit.nil?
 
-        estimate = query("SELECT reltuples AS estimate FROM pg_class where relname = '#{table_name}';")
+        row, = query("SELECT reltuples AS estimate FROM pg_class where relname = '#{table_name}';")
+        estimate, = row
 
         estimate <= SafePgMigrations.config.backfill_batch_size_limit
       end

--- a/lib/safe-pg-migrations/plugins/strong_migrations_integration.rb
+++ b/lib/safe-pg-migrations/plugins/strong_migrations_integration.rb
@@ -9,7 +9,7 @@ module SafePgMigrations
         StrongMigrations.disable_check(:add_column_default)
         StrongMigrations.disable_check(:add_column_default_callable)
         StrongMigrations.add_check do |method, args|
-          break unless method == :add_column
+          next unless method == :add_column
 
           options = args.last.is_a?(Hash) ? args.last : {}
 

--- a/lib/safe-pg-migrations/plugins/strong_migrations_integration.rb
+++ b/lib/safe-pg-migrations/plugins/strong_migrations_integration.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module SafePgMigrations
+  module StrongMigrationsIntegration
+    class << self
+      def initialize
+        return unless strong_migration_available?
+
+        StrongMigrations.disable_check(:add_column_default)
+        StrongMigrations.disable_check(:add_column_default_callable)
+        StrongMigrations.add_check do |method, args|
+          break unless method == :add_column
+
+          options = args.last.is_a?(Hash) ? args.last : {}
+
+          default_value_backfill = options.fetch(:default_value_backfill, :auto)
+
+          if default_value_backfill == :update_in_batches
+            check_message = <<~CHECK
+              default_value_backfill: :update_in_batches will take time if the table is too big.
+
+              Your configuration sets a pause of #{SafePgMigrations.config.backfill_pause} seconds between batches of
+              #{SafePgMigrations.config.backfill_batch_size} rows. Each batch execution will take time as well. Please
+              check that the estimated duration of the migration is acceptable
+              before adding `safety_assured`.
+            CHECK
+
+            check_message += <<~CHECK if SafePgMigrations.config.backfill_batch_size_limit
+
+              Also, please note that SafePgMigrations is configured to raise if the table has more than
+              #{SafePgMigrations.config.backfill_batch_size_limit} rows.
+            CHECK
+
+            stop! check_message
+          end
+        end
+      end
+
+      private
+
+      def strong_migration_available?
+        Object.const_defined? :StrongMigrations
+      end
+    end
+  end
+end

--- a/lib/safe-pg-migrations/railtie.rb
+++ b/lib/safe-pg-migrations/railtie.rb
@@ -9,6 +9,34 @@ module SafePgMigrations
         ActiveRecord::Migration.prepend(SafePgMigrations::Migration)
         ActiveRecord::Migration.singleton_class.prepend(SafePgMigrations::Migration::ClassMethods)
       end
+
+      break unless Object.const_defined? :StrongMigrations
+
+      StrongMigrations.add_check do |method, args|
+        break unless method == :add_column
+
+        options = args.last.is_a?(Hash) ? args.last : {}
+
+        default_value_backfill = options.fetch(:default_value_backfill, :auto)
+
+        if default_value_backfill == :update_in_batches
+          check_message = <<~CHECK
+            default_value_backfill: :update_in_batches will take time if the table is too big.
+
+            Your configuration sets a pause of #{SafePgMigrations.config.backfill_pause} seconds between batches of
+            #{SafePgMigrations.config.backfill_batch_size} rows. Each batch execution will take time as well. Please
+            check that the estimated duration of the migration is acceptable before adding `safety_assured`.
+          CHECK
+
+          check_message += <<~CHECK if SafePgMigrations.config.backfill_batch_size_limit
+
+            Also, please note that SafePgMigrations is configured to raise if the table has more than
+            #{SafePgMigrations.config.backfill_batch_size_limit} rows.
+          CHECK
+
+          stop! check_message
+        end
+      end
     end
   end
 end

--- a/test/StatementInsurer/add_column_test.rb
+++ b/test/StatementInsurer/add_column_test.rb
@@ -259,6 +259,28 @@ module StatementInsurer
       assert_equal 5, @connection.query_value("SELECT count(*) FROM users WHERE email = 'roger@doctolib.com'")
     end
 
+    def test_raises_if_default_value_backfill_and_too_big_table
+      skip_if_unmet_requirements!
+      SafePgMigrations.config.backfill_batch_size_limit = 4
+
+      @connection.execute('INSERT INTO users (id) VALUES (default);')
+      @connection.execute('INSERT INTO users (id) VALUES (default);')
+      @connection.execute('INSERT INTO users (id) VALUES (default);')
+      @connection.execute('INSERT INTO users (id) VALUES (default);')
+      @connection.execute('INSERT INTO users (id) VALUES (default);')
+      @connection.execute('VACUUM users;') # update size estimation, otherwise it would be 0
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            add_column :users, :email, :string, default: 'roger@doctolib.com', null: false,
+                                                default_value_backfill: :update_in_batches
+          end
+        end.new
+
+      assert_raises(StandardError, 'Table users has more than 4 rows') { run_migration }
+    end
+
     private
 
     def skip_if_unmet_requirements!

--- a/test/strong_migration_integration_test.rb
+++ b/test/strong_migration_integration_test.rb
@@ -2,7 +2,6 @@
 
 begin
   require 'strong_migrations'
-  StrongMigrations.start_after = 0
 rescue LoadError
   # strong_migrations not installed
 end
@@ -15,6 +14,8 @@ class StrongMigrationIntegrationTest < Minitest::Test
     SafePgMigrations::StrongMigrationsIntegration.initialize
 
     super
+
+    ENV.delete 'SAFETY_ASSURED'
   end
 
   def test_add_column_no_safety_assured

--- a/test/strong_migration_integration_test.rb
+++ b/test/strong_migration_integration_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+begin
+  require 'strong_migrations'
+  StrongMigrations.start_after = 0
+rescue LoadError
+  # strong_migrations not installed
+end
+
+require 'test_helper'
+
+class StrongMigrationIntegrationTest < Minitest::Test
+  def setup
+    skip 'Strong migrations not installed' unless Object.const_defined? :StrongMigrations
+    SafePgMigrations::StrongMigrationsIntegration.initialize
+
+    super
+  end
+
+  def test_add_column_no_safety_assured
+    @connection.create_table(:users)
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def up
+          add_column :users, :name, :string
+        end
+      end.new
+
+    run_migration
+  end
+
+  def test_add_column_without_safety_assured_and_backfill_in_batches_raises
+    @connection.create_table(:users)
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def up
+          add_column :users, :name, :string, default: lambda {
+                                                        'NOW()'
+                                                      }, null: false, default_value_backfill: :update_in_batches
+        end
+      end.new
+
+    exception = assert_raises(StandardError, 'Dangerous operation detected #strong_migrations') { run_migration }
+    assert_equal <<~EXCEPTION, exception.message
+      An error has occurred, all later migrations canceled:
+
+
+      === Custom check #strong_migrations ===
+
+      default_value_backfill: :update_in_batches will take time if the table is too big.
+
+      Your configuration sets a pause of 0.5 seconds between batches of
+      100000 rows. Each batch execution will take time as well. Please
+      check that the estimated duration of the migration is acceptable
+      before adding `safety_assured`.
+
+    EXCEPTION
+  end
+
+  def test_add_column_with_safety_assured_and_backfill_in_batches_no_raise
+    @connection.create_table(:users)
+
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def up
+          safety_assured do
+            add_column :users,
+                       :name, :string, default: -> { 'NOW()' }, null: false, default_value_backfill: :update_in_batches
+          end
+        end
+      end.new
+
+    run_migration
+  end
+
+  def test_rename_column_should_not_be_available_without_safety_assured
+    @connection.create_table(:users) { |t| t.string :email }
+    @migration =
+      Class.new(ActiveRecord::Migration::Current) do
+        def up
+          rename_column :users, :email, :name
+        end
+      end.new
+
+    assert_raises(StandardError, 'Dangerous operation detected #strong_migrations') { run_migration }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ class Minitest::Test
   make_my_diffs_pretty!
 
   def setup
+    ENV['SAFETY_ASSURED'] = '1'
     ActiveRecord::Base.establish_connection
     SafePgMigrations.instance_variable_set(:@config, nil)
     @verbose_was = ActiveRecord::Migration.verbose

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,6 @@ require 'mocha/minitest'
 require 'active_record'
 require 'active_support'
 require 'pry'
-
 require 'safe-pg-migrations/base'
 
 ENV['POSTGRES_USER'] ||= ENV.fetch('USER', nil)

--- a/test/verbose_sql_logger_test.rb
+++ b/test/verbose_sql_logger_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
 class VerboseSqlLoggerTest < Minitest::Test
   def setup
     @migration =
@@ -98,8 +97,8 @@ class VerboseSqlLoggerTest < Minitest::Test
 
     assert_match('SHOW lock_timeout', logs[0])
     assert_match("SET lock_timeout TO '4950ms'", logs[1])
-    assert_match('SELECT * from pg_stat_activity', logs[2])
-    assert_match('SELECT version()', logs[3])
-    assert_match("SET lock_timeout TO '70s'", logs[4])
+    assert_match('SELECT * from pg_stat_activity', logs[-3])
+    assert_match('SELECT version()', logs[-2])
+    assert_match("SET lock_timeout TO '70s'", logs[-1])
   end
 end


### PR DESCRIPTION
`add_column` with `default_value_backfill: :update_in_batches` can be dangerous on big tables. To avoid unwanted long migrations, **Safe PG Migrations** does not automatically mark this usage as safe when used with `strong-migrations`, usage of `safety_assured` is required.

It is also possible to set a threshold for the table size, above which the migration will fail. This can be done by setting the `default_value_backfill_threshold:` option in the configuration.
