### PR TITLE
drop_table: Remove foreign keys before removing a column

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ If you cannot afford to log this type of data, you can either
 
 </details>
 
+<details><summary>Dropping a table</summary>
+
+Dropping a table can be difficult to achieve in a small amount of time if it holds several foreign keys to busy tables.
+To remove the table, PostgreSQL will have to acquire an access exclusive lock on all the tables referenced by the foreign keys.
+
+To solve this issue, **Safe Pg Migrations** will drop the foreign keys before dropping the table.
+
+---
+**NOTE**
+
+Dropping a table is a dangerous operation by nature. **Safe Pg Migrations** will not prevent the deletion of a table which
+would still be in use.
+
+---
+
+</details>
+
 <details><summary>Verbose SQL logging</summary>
 
 For any operation, **Safe PG Migrations** can output the performed SQL queries. This feature is enabled by default in a production Rails environment. If you want to explicit enable it, for example in your development environment you can use:

--- a/lib/safe-pg-migrations/plugins/idempotent_statements.rb
+++ b/lib/safe-pg-migrations/plugins/idempotent_statements.rb
@@ -131,5 +131,13 @@ module SafePgMigrations
         /!\\ Column '#{table_name}.#{column.name}' is already set to 'default: #{column.default}'. Skipping statement.
       MESSAGE
     end
+
+    ruby2_keywords def drop_table(table_name, *)
+      return super if table_exists?(table_name)
+
+      Helpers::Logger.say <<~MESSAGE.squish, sub_item: true
+        /!\\ Table '#{table_name} does not exist. Skipping statement.
+      MESSAGE
+    end
   end
 end

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -107,6 +107,20 @@ validate: false
       end
     end
 
+    ruby2_keywords def drop_table(table_name, *args)
+      foreign_keys(table_name).each do |foreign_key|
+        with_setting(:statement_timeout, SafePgMigrations.config.pg_statement_timeout) do
+          remove_foreign_key(table_name, name: foreign_key.name)
+        end
+      end
+
+      Helpers::Logger.say_method_call :drop_table, table_name, *args
+
+      with_setting(:statement_timeout, SafePgMigrations.config.pg_statement_timeout) do
+        super(table_name, *args)
+      end
+    end
+
     def with_setting(key, value)
       old_value = query_value("SHOW #{key}")
       execute("SET #{key} TO #{quote(value)}")

--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SafePgMigrations
-  module StatementInsurer
+  module StatementInsurer # rubocop:disable Metrics/ModuleLength
     include AddColumn
 
     %i[change_column].each do |method|
@@ -96,6 +96,15 @@ validate: false
       Helpers::Logger.say_method_call :remove_check_constraint, table_name,
                                       "#{column_name} IS NOT NULL"
       remove_check_constraint table_name, "#{column_name} IS NOT NULL"
+    end
+
+    def remove_column(table_name, column_name, *)
+      foreign_key = foreign_key_for(table_name, column: column_name)
+
+      with_setting(:statement_timeout, SafePgMigrations.config.pg_statement_timeout) do
+        remove_foreign_key(table_name, name: foreign_key.name) if foreign_key
+        super
+      end
     end
 
     def with_setting(key, value)

--- a/test/IdempotentStatements/drop_table_test.rb
+++ b/test/IdempotentStatements/drop_table_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module IdempotentStatements
+  class AddColumnTest < Minitest::Test
+    def setup
+      super
+
+      @connection.create_table(:appointments) { |t| t.string :email }
+      @connection.create_table(:patients) { |t| t.string :email }
+      @connection.create_table(:users) do |t|
+        t.string :name
+        t.references :appointment, foreign_key: true
+        t.references :patient, foreign_key: true
+      end
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            drop_table(:users)
+          end
+        end.new
+    end
+
+    def test_first_fk_already_removed
+      @connection.remove_foreign_key(:users, name: 'fk_rails_253ea793f9')
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls <<~CALLS.strip.split("\n"), calls
+        SET statement_timeout TO '5s'
+        ALTER TABLE "users" DROP CONSTRAINT "fk_rails_d15efa01b1"
+        SET statement_timeout TO '70s'
+        SET statement_timeout TO '5s'
+        DROP TABLE "users"
+        SET statement_timeout TO '70s'
+      CALLS
+    end
+
+    def test_fks_already_removed
+      @connection.remove_foreign_key(:users, name: 'fk_rails_253ea793f9')
+      @connection.remove_foreign_key(:users, name: 'fk_rails_d15efa01b1')
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls <<~CALLS.strip.split("\n"), calls
+        SET statement_timeout TO '5s'
+        DROP TABLE "users"
+        SET statement_timeout TO '70s'
+      CALLS
+    end
+  end
+end

--- a/test/StatementInsurer/drop_table_test.rb
+++ b/test/StatementInsurer/drop_table_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module StatementInsurer
+  class DropTableTest < Minitest::Test
+    def test_can_drop_table_without_foreign_keys
+      @connection.create_table(:users) { |t| t.string :email }
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            drop_table(:users)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls ["SET statement_timeout TO '5s'", 'DROP TABLE "users"', "SET statement_timeout TO '70s'"],
+                   calls
+    end
+
+    def test_can_drop_table_with_foreign_key
+      @connection.create_table(:appointments) { |t| t.string :email }
+      @connection.create_table(:users) do |t|
+        t.string :email
+        t.references :appointment, foreign_key: true
+      end
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            drop_table(:users)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls [
+        "SET statement_timeout TO '5s'",
+        'ALTER TABLE "users" DROP CONSTRAINT "fk_rails_253ea793f9"',
+        "SET statement_timeout TO '70s'",
+        "SET statement_timeout TO '5s'",
+        'DROP TABLE "users"',
+        "SET statement_timeout TO '70s'",
+      ], calls
+    end
+
+    def test_can_drop_table_with_several_foreign_keys
+      @connection.create_table(:appointments) { |t| t.string :email }
+      @connection.create_table(:patients) { |t| t.string :email }
+      @connection.create_table(:users) do |t|
+        t.string :email
+        t.references :appointment, foreign_key: true
+        t.references :patient, foreign_key: true
+      end
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            drop_table(:users)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls [
+        "SET statement_timeout TO '5s'",
+        'ALTER TABLE "users" DROP CONSTRAINT "fk_rails_253ea793f9"',
+        "SET statement_timeout TO '70s'",
+        "SET statement_timeout TO '5s'",
+        'ALTER TABLE "users" DROP CONSTRAINT "fk_rails_d15efa01b1"',
+        "SET statement_timeout TO '70s'",
+        "SET statement_timeout TO '5s'",
+        'DROP TABLE "users"',
+        "SET statement_timeout TO '70s'",
+      ], calls
+    end
+  end
+end

--- a/test/StatementInsurer/remove_column_test.rb
+++ b/test/StatementInsurer/remove_column_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+module StatementInsurer
+  class RemoveColumnTest < Minitest::Test
+    def test_can_remove_column_with_foreign_key
+      @connection.create_table(:users)
+      @connection.create_table(:passwords)
+      @connection.add_reference(:users, :password, foreign_key: true)
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            remove_column(:users, :password_id)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_equal ['ALTER TABLE "users" DROP CONSTRAINT "fk_rails_baad13daec"'], calls[2]
+      assert_equal ['ALTER TABLE "users" DROP COLUMN "password_id"'], calls[3]
+    end
+
+    def test_can_remove_column_with_foreign_key_on_other_column
+      @connection.create_table(:users) { |t| t.string :name }
+      @connection.create_table(:passwords)
+      @connection.add_reference(:users, :password, foreign_key: true)
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            remove_column(:users, :name)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_equal ['ALTER TABLE "users" DROP COLUMN "name"'], calls[2]
+    end
+
+    def test_can_remove_column_without_foreign_key
+      @connection.create_table(:users) { |t| t.string :name }
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            remove_column(:users, :name)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_equal ['ALTER TABLE "users" DROP COLUMN "name"'], calls[2]
+    end
+  end
+end


### PR DESCRIPTION
Dropping a table can be difficult to achieve in a small amount of time if it holds several foreign keys to busy tables.
To remove the table, PostgreSQL will have to acquire an access exclusive lock on all the tables referenced by the foreign keys.

To solve this issue, **Safe Pg Migrations** will drop the foreign keys before dropping the table.

---
**NOTE**


Dropping a table is a dangerous operation by nature. **Safe Pg Migrations** will not prevent the deletion of a table which
would still be in use.

---