### PR TITLE
Upgrade gem versions to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    safe-pg-migrations (2.3.1)
+    safe-pg-migrations (3.0.0)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
 

--- a/lib/safe-pg-migrations/version.rb
+++ b/lib/safe-pg-migrations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SafePgMigrations
-  VERSION = '2.3.1'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
We are upgrading the gem to `v3.0.0` as the dependencies have change, notably: 
- The support of `ActiveRecord 7.1` and above 
- The drop of `ActiveRecord 6.0` (support starts now at `6.1`)
- The drop of `Ruby 2.X` versions