### PR TITLE
Fix args bug for create_table

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_insurer.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer.rb
@@ -42,7 +42,7 @@ module SafePgMigrations
       validate_foreign_key from_table, sub_options.present? ? nil : to_table, **sub_options
     end
 
-    def create_table(*)
+    def create_table(table_name, **options)
       super do |td|
         yield td if block_given?
         td.indexes.map! do |key, index_options|

--- a/test/StatementInsurer/statement_insurer_test.rb
+++ b/test/StatementInsurer/statement_insurer_test.rb
@@ -147,7 +147,7 @@ module StatementInsurer
       @migration =
         Class.new(ActiveRecord::Migration::Current) do
           def change
-            create_table(:users) do |t|
+            create_table(:users, primary_key: nil) do |t|
               t.string :email
               t.references :user, foreign_key: true
             end


### PR DESCRIPTION
We had a bug that forbid to have more than one args for `create_table`
This was due to a missing update of `create_table` in `statement_insurer.rb`

we also enrich one test to spot those kind of issue in the future.