### PR TITLE
BatchRecord: select primary keys instead of full records

### DIFF
--- a/lib/safe-pg-migrations/helpers/batch_over.rb
+++ b/lib/safe-pg-migrations/helpers/batch_over.rb
@@ -19,11 +19,11 @@ module SafePgMigrations
       def next_batch
         return if endless?
 
-        first = next_scope.take
+        first = next_scope.select(primary_key).take
 
         return unless first
 
-        last = next_scope.offset(@of).take
+        last = next_scope.select(primary_key).offset(@of).take
 
         first_key = first[primary_key]
         last_key = last.nil? ? nil : last[primary_key]


### PR DESCRIPTION
It can help performance by avoiding table lookups and reducing network usage.

For the potential gains, see benchmark: https://github.com/doctolib/safe-pg-migrations/pull/136#issuecomment-1963847811