### PR TITLE
Tt 23249 increment lock_timeout gradually to reduce failing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,9 @@ SafePgMigrations.config.safe_timeout = 5.seconds # Statement timeout used for al
 
 SafePgMigrations.config.lock_timeout = nil # Lock timeout used for all DDL operations except from CREATE / DROP INDEX. If not set, safe_timeout will be used with a deduction of 1% to ensure that the lock timeout is raised in priority
 
-SafePgMigrations.config.max_lock_timeout_for_retry = 1.second # Max lock timeout for the retries for all DDL operations except from CREATE / DROP INDEX. Each retry will increase the lock_timeout by (max_lock_timeout_for_retry - lock_timeout) / max_tries
+SafePgMigrations.config.increase_lock_timeout_on_retry # Activate the lock timeout increase feature on retry if set to true. See max_lock_timeout_for_retry for more information.
+
+SafePgMigrations.config.max_lock_timeout_for_retry = 1.second # Max lock timeout for the retries for all DDL operations except from CREATE / DROP INDEX. Each retry will increase the lock_timeout (if increase_lock_timeout_on_retry option is set to true) by (max_lock_timeout_for_retry - lock_timeout) / max_tries
 
 SafePgMigrations.config.blocking_activity_logger_verbose = true # Outputs the raw blocking queries on timeout. When false, outputs information about the lock instead
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ SafePgMigrations.config.safe_timeout = 5.seconds # Statement timeout used for al
 
 SafePgMigrations.config.lock_timeout = nil # Lock timeout used for all DDL operations except from CREATE / DROP INDEX. If not set, safe_timeout will be used with a deduction of 1% to ensure that the lock timeout is raised in priority
 
+SafePgMigrations.config.max_lock_timeout_for_retry = 1.second # Max lock timeout for the retries for all DDL operations except from CREATE / DROP INDEX. Each retry will increase the lock_timeout by (max_lock_timeout_for_retry - lock_timeout) / max_tries
+
 SafePgMigrations.config.blocking_activity_logger_verbose = true # Outputs the raw blocking queries on timeout. When false, outputs information about the lock instead
 
 SafePgMigrations.config.sensitive_logger = nil # When given, sensitive data will be sent to this logger instead of the standard output. Must implement method `info`.

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -13,6 +13,7 @@ module SafePgMigrations
                     max_tries
                     retry_delay
                     sensitive_logger
+                    increase_lock_timeout_on_retry
                   ])
     attr_reader :lock_timeout, :safe_timeout, :max_lock_timeout_for_retry
 
@@ -28,6 +29,7 @@ module SafePgMigrations
       self.max_tries = 5
       self.max_lock_timeout_for_retry = 1.second
       self.sensitive_logger = nil
+      self.increase_lock_timeout_on_retry = false
     end
 
     def lock_timeout=(value)

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -10,26 +10,26 @@ module SafePgMigrations
                     blocking_activity_logger_margin
                     blocking_activity_logger_verbose
                     default_value_backfill_threshold
+                    increase_lock_timeout_on_retry
                     max_tries
                     retry_delay
                     sensitive_logger
-                    increase_lock_timeout_on_retry
                   ])
     attr_reader :lock_timeout, :safe_timeout, :max_lock_timeout_for_retry
 
     def initialize
-      self.default_value_backfill_threshold = nil
-      self.safe_timeout = 5.seconds
-      self.lock_timeout = nil
-      self.blocking_activity_logger_margin = 1.second
-      self.blocking_activity_logger_verbose = true
       self.backfill_batch_size = 100_000
       self.backfill_pause = 0.5.second
-      self.retry_delay = 1.minute
-      self.max_tries = 5
-      self.max_lock_timeout_for_retry = 1.second
-      self.sensitive_logger = nil
+      self.blocking_activity_logger_margin = 1.second
+      self.blocking_activity_logger_verbose = true
+      self.default_value_backfill_threshold = nil
       self.increase_lock_timeout_on_retry = false
+      self.lock_timeout = nil
+      self.max_lock_timeout_for_retry = 1.second
+      self.max_tries = 5
+      self.retry_delay = 1.minute
+      self.safe_timeout = 5.seconds
+      self.sensitive_logger = nil
     end
 
     def lock_timeout=(value)

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -33,7 +33,7 @@ module SafePgMigrations
     def lock_timeout=(value)
       raise 'Setting lock timeout to 0 disables the lock timeout and is dangerous' if value == 0.seconds
 
-      unless value.nil? || (value < safe_timeout && value < max_lock_timeout_on_retry)
+      unless value.nil? || (value < safe_timeout && value < max_lock_timeout_for_retry)
         raise ArgumentError, "Lock timeout (#{value}) cannot be greater than the safe timeout (#{safe_timeout}) or the max lock timeout for retry (#{max_lock_timeout_for_retry})"
       end
 

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -5,16 +5,16 @@ require 'active_support/core_ext/numeric/time'
 module SafePgMigrations
   class Configuration
     attr_accessor(*%i[
+                    backfill_batch_size
+                    backfill_pause
                     blocking_activity_logger_margin
                     blocking_activity_logger_verbose
                     default_value_backfill_threshold
-                    backfill_batch_size
-                    backfill_pause
-                    retry_delay
+                    lock_timeout
                     max_tries
                     max_lock_timeout
+                    retry_delay
                     sensitive_logger
-                    lock_timeout
                   ])
     attr_reader :safe_timeout
 

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -33,7 +33,7 @@ module SafePgMigrations
     def lock_timeout=(value)
       raise 'Setting lock timeout to 0 disables the lock timeout and is dangerous' if value == 0.seconds
 
-      unless value.nil? || (value < safe_timeout && value < max_lock_timeout_for_retry)
+      unless value.nil? || (value < safe_timeout && value <= max_lock_timeout_for_retry)
         raise ArgumentError, "Lock timeout (#{value}) cannot be greater than the safe timeout (#{safe_timeout}) or the max lock timeout for retry (#{max_lock_timeout_for_retry})"
       end
 
@@ -43,15 +43,15 @@ module SafePgMigrations
     def safe_timeout=(value)
       raise 'Setting safe timeout to 0 or nil disables the safe timeout and is dangerous' unless value && value > 0.seconds
 
-      unless lock_timeout.nil? || (value > lock_timeout && value > max_lock_timeout_for_retry)
+      unless lock_timeout.nil? || (value > lock_timeout && value >= max_lock_timeout_for_retry)
         raise ArgumentError, "Safe timeout (#{value}) cannot be lower than the lock timeout (#{lock_timeout}) or the max lock timeout for retry (#{max_lock_timeout_for_retry})"
       end
 
       @safe_timeout = value
     end
 
-    def max_lock_timeout_for_retry(value)
-      unless lock_timeout.nil? || (value > lock_timeout && value < safe_timeout)
+    def max_lock_timeout_for_retry=(value)
+      unless lock_timeout.nil? || (value >= lock_timeout && value <= safe_timeout)
         raise ArgumentError, "Max lock timeout for retry (#{value}) cannot be lower than the lock timeout (#{lock_timeout}) and greater than the safe timeout (#{safe_timeout})"
       end
 

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -12,10 +12,11 @@ module SafePgMigrations
                     backfill_pause
                     retry_delay
                     max_tries
+                    max_lock_timeout
                     sensitive_logger
                     lock_timeout
-                    safe_timeout
                   ])
+    attr_reader :safe_timeout
 
     def initialize
       self.default_value_backfill_threshold = nil
@@ -27,6 +28,7 @@ module SafePgMigrations
       self.backfill_pause = 0.5.second
       self.retry_delay = 1.minute
       self.max_tries = 5
+      self.max_lock_timeout = 1.second
       self.sensitive_logger = nil
     end
 
@@ -43,7 +45,7 @@ module SafePgMigrations
     def safe_timeout=(value)
       raise 'Setting safe timeout to 0 disables the safe timeout and is dangerous' unless value
 
-      unless lock_timeout.nil? || value > lock_timeout
+      unless lock_timeout.nil? || value > lock_timeout || value > max_lock_timeout
         raise ArgumentError, "Safe timeout (#{value}) cannot be less than lock timeout (#{lock_timeout})"
       end
 

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -36,17 +36,21 @@ module SafePgMigrations
       raise 'Setting lock timeout to 0 disables the lock timeout and is dangerous' if value == 0.seconds
 
       unless value.nil? || (value < safe_timeout && value <= max_lock_timeout_for_retry)
-        raise ArgumentError, "Lock timeout (#{value}) cannot be greater than the safe timeout (#{safe_timeout}) or the max lock timeout for retry (#{max_lock_timeout_for_retry})"
+        raise ArgumentError, "Lock timeout (#{value}) cannot be greater than the safe timeout (#{safe_timeout}) or the
+                              max lock timeout for retry (#{max_lock_timeout_for_retry})"
       end
 
       @lock_timeout = value
     end
 
     def safe_timeout=(value)
-      raise 'Setting safe timeout to 0 or nil disables the safe timeout and is dangerous' unless value && value > 0.seconds
+      unless value && value > 0.seconds
+        raise 'Setting safe timeout to 0 or nil disables the safe timeout and is dangerous'
+      end
 
       unless lock_timeout.nil? || (value > lock_timeout && value >= max_lock_timeout_for_retry)
-        raise ArgumentError, "Safe timeout (#{value}) cannot be lower than the lock timeout (#{lock_timeout}) or the max lock timeout for retry (#{max_lock_timeout_for_retry})"
+        raise ArgumentError, "Safe timeout (#{value}) cannot be lower than the lock timeout (#{lock_timeout}) or the
+                              max lock timeout for retry (#{max_lock_timeout_for_retry})"
       end
 
       @safe_timeout = value
@@ -54,7 +58,8 @@ module SafePgMigrations
 
     def max_lock_timeout_for_retry=(value)
       unless lock_timeout.nil? || (value >= lock_timeout && value <= safe_timeout)
-        raise ArgumentError, "Max lock timeout for retry (#{value}) cannot be lower than the lock timeout (#{lock_timeout}) and greater than the safe timeout (#{safe_timeout})"
+        raise ArgumentError, "Max lock timeout for retry (#{value}) cannot be lower than the lock timeout
+                              (#{lock_timeout}) and greater than the safe timeout (#{safe_timeout})"
       end
 
       @max_lock_timeout_for_retry = value

--- a/lib/safe-pg-migrations/configuration.rb
+++ b/lib/safe-pg-migrations/configuration.rb
@@ -13,8 +13,9 @@ module SafePgMigrations
                     retry_delay
                     max_tries
                     sensitive_logger
+                    lock_timeout
+                    safe_timeout
                   ])
-    attr_reader :lock_timeout, :safe_timeout
 
     def initialize
       self.default_value_backfill_threshold = nil

--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -21,10 +21,12 @@ module SafePgMigrations
         raise if transaction_open? # Retrying is useless if we're inside a transaction.
         raise if number_of_retries >= SafePgMigrations.config.max_tries
 
-        if SafePgMigrations.config.lock_timeout < SafePgMigrations.config.max_lock_timeout
-          SafePgMigrations.config.lock_timeout = SafePgMigrations.config.lock_timeout * number_of_retries
-        else
-          SafePgMigrations.config.lock_timeout = SafePgMigrations.config.max_lock_timeout
+        unless SafePgMigrations.config.lock_timeout.nil?
+          if SafePgMigrations.config.lock_timeout < SafePgMigrations.config.max_lock_timeout
+            SafePgMigrations.config.lock_timeout = SafePgMigrations.config.lock_timeout * number_of_retries
+          else
+            SafePgMigrations.config.lock_timeout = SafePgMigrations.config.max_lock_timeout
+          end
         end
 
         retry_delay = SafePgMigrations.config.retry_delay

--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -28,7 +28,9 @@ module SafePgMigrations
         retry_delay = SafePgMigrations.config.retry_delay
         Helpers::Logger.say "Retrying in #{retry_delay} seconds...", sub_item: true
 
-        increase_lock_timeout if SafePgMigrations.config.increase_lock_timeout_on_retry && !SafePgMigrations.config.lock_timeout.nil?
+        if SafePgMigrations.config.increase_lock_timeout_on_retry && !SafePgMigrations.config.lock_timeout.nil?
+          increase_lock_timeout
+        end
 
         sleep retry_delay
         Helpers::Logger.say 'Retrying now.', sub_item: true
@@ -37,7 +39,8 @@ module SafePgMigrations
     end
 
     def increase_lock_timeout
-      Helpers::Logger.say "  Increasing the lock timeout... Currently set to #{SafePgMigrations.config.lock_timeout}", sub_item: true
+      Helpers::Logger.say "  Increasing the lock timeout... Currently set to #{SafePgMigrations.config.lock_timeout}",
+                          sub_item: true
       SafePgMigrations.config.lock_timeout = (SafePgMigrations.config.lock_timeout + lock_timeout_step)
       unless SafePgMigrations.config.lock_timeout < SafePgMigrations.config.max_lock_timeout_for_retry
         SafePgMigrations.config.lock_timeout = SafePgMigrations.config.max_lock_timeout_for_retry
@@ -46,7 +49,10 @@ module SafePgMigrations
     end
 
     def lock_timeout_step
-      @lock_timeout_step ||= (SafePgMigrations.config.max_lock_timeout_for_retry - SafePgMigrations.config.lock_timeout) / (SafePgMigrations.config.max_tries - 1)
+      max_lock_timeout_for_retry = SafePgMigrations.config.max_lock_timeout_for_retry
+      lock_timeout = SafePgMigrations.config.lock_timeout
+      max_tries = SafePgMigrations.config.max_tries
+      @lock_timeout_step ||= (max_lock_timeout_for_retry - lock_timeout) / (max_tries - 1)
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -13,21 +13,16 @@ module SafePgMigrations
     private
 
     def retry_if_lock_timeout
+      lock_timeout_step = get_lock_timeout_step(SafePgMigrations.config)
       number_of_retries = 0
       begin
         number_of_retries += 1
         yield
       rescue ActiveRecord::LockWaitTimeout
         raise if transaction_open? # Retrying is useless if we're inside a transaction.
-        raise if number_of_retries >= SafePgMigrations.config.max_tries
+        raise if number_of_retries >= max_tries
 
-        unless SafePgMigrations.config.lock_timeout.nil?
-          if SafePgMigrations.config.lock_timeout < SafePgMigrations.config.max_lock_timeout
-            SafePgMigrations.config.lock_timeout = SafePgMigrations.config.lock_timeout * number_of_retries
-          else
-            SafePgMigrations.config.lock_timeout = SafePgMigrations.config.max_lock_timeout
-          end
-        end
+        increase_lock_timeout(lock_timeout_step) unless SafePgMigrations.config.lock_timeout.nil?
 
         retry_delay = SafePgMigrations.config.retry_delay
         Helpers::Logger.say "Retrying in #{retry_delay} seconds...", sub_item: true
@@ -35,6 +30,17 @@ module SafePgMigrations
         Helpers::Logger.say 'Retrying now.', sub_item: true
         retry
       end
+    end
+
+    def increase_lock_timeout(lock_timeout_step)
+      SafePgMigrations.config.lock_timeout += lock_timeout_step
+      unless SafePgMigrations.config.lock_timeout < SafePgMigrations.config.max_lock_timeout_for_retry
+        SafePgMigrations.config.lock_timeout = SafePgMigrations.config.max_lock_timeout_for_retry
+      end
+    end
+
+    def get_lock_timeout_step(config)
+      (config.max_lock_timeout_for_retry - config.lock_timeout) / config.max_tries
     end
   end
 end

--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -21,6 +21,15 @@ module SafePgMigrations
         raise if transaction_open? # Retrying is useless if we're inside a transaction.
         raise unless remaining_tries > 0
 
+        number_of_retries = SafePgMigrations.config.max_tries - remaining_tries
+        if SafePgMigrations.config.max_tries - remaining_tries <= 20
+          SafePgMigrations.config.lock_timeout = SafePgMigrations.config.lock_timeout * number_of_retries
+          SafePgMigrations.config.safe_timeout = SafePgMigrations.config.safe_timeout * number_of_retries
+        else
+          SafePgMigrations.config.lock_timeout = SafePgMigrations.config.lock_timeout * 20
+          SafePgMigrations.config.safe_timeout = SafePgMigrations.config.safe_timeout * 20
+        end
+
         retry_delay = SafePgMigrations.config.retry_delay
         Helpers::Logger.say "Retrying in #{retry_delay} seconds...", sub_item: true
         sleep retry_delay

--- a/lib/safe-pg-migrations/plugins/statement_retrier.rb
+++ b/lib/safe-pg-migrations/plugins/statement_retrier.rb
@@ -28,7 +28,7 @@ module SafePgMigrations
         retry_delay = SafePgMigrations.config.retry_delay
         Helpers::Logger.say "Retrying in #{retry_delay} seconds...", sub_item: true
 
-        increase_lock_timeout unless SafePgMigrations.config.lock_timeout.nil?
+        increase_lock_timeout if SafePgMigrations.config.increase_lock_timeout_on_retry && !SafePgMigrations.config.lock_timeout.nil?
 
         sleep retry_delay
         Helpers::Logger.say 'Retrying now.', sub_item: true

--- a/test/statement_retrier_test.rb
+++ b/test/statement_retrier_test.rb
@@ -48,4 +48,8 @@ class StatementRetrierTest < Minitest::Test
       '   -> Retrying now.',
     ], calls[7..9]
   end
+
+  def lock_timout_increase_on_retry
+
+  end
 end

--- a/test/statement_retrier_test.rb
+++ b/test/statement_retrier_test.rb
@@ -91,15 +91,13 @@ class StatementRetrierTest < Minitest::Test
 
     @connection.expects(:sleep).times(4)
 
-    calls =
-      record_calls(@migration, :write) do
-        run_migration
-        flunk 'run_migration should raise'
-      rescue StandardError => e
-        assert_instance_of ActiveRecord::LockWaitTimeout, e.cause
-        assert_includes e.cause.message, 'canceling statement due to lock timeout'
-      end
 
-    calls
+    record_calls(@migration, :write) do
+      run_migration
+      flunk 'run_migration should raise'
+    rescue StandardError => e
+      assert_instance_of ActiveRecord::LockWaitTimeout, e.cause
+      assert_includes e.cause.message, 'canceling statement due to lock timeout'
+    end
   end
 end

--- a/test/statement_retrier_test.rb
+++ b/test/statement_retrier_test.rb
@@ -4,24 +4,8 @@ require 'test_helper'
 
 class StatementRetrierTest < Minitest::Test
   def test_retry_if_lock_timeout
-    @migration =
-      Class.new(ActiveRecord::Migration::Current) do
-        def up
-          connection.send(:retry_if_lock_timeout) do
-            raise ActiveRecord::LockWaitTimeout, 'PG::LockNotAvailable: ERROR:  canceling statement due to lock timeout'
-          end
-        end
-      end.new
+    calls = calls_for_lock_timeout_migration
 
-    @connection.expects(:sleep).times(4)
-    calls =
-      record_calls(@migration, :write) do
-        run_migration
-        flunk 'run_migration should raise'
-      rescue StandardError => e
-        assert_instance_of ActiveRecord::LockWaitTimeout, e.cause
-        assert_includes e.cause.message, 'canceling statement due to lock timeout'
-      end
     assert_equal [
       '   -> Retrying in 60 seconds...',
       '   -> Retrying now.',
@@ -49,7 +33,54 @@ class StatementRetrierTest < Minitest::Test
     ], calls[7..9]
   end
 
-  def lock_timout_increase_on_retry
+  def test_lock_timout_increase_on_retry
+    SafePgMigrations.config.lock_timeout = 0.1.seconds
 
+    calls = calls_for_lock_timeout_migration
+
+    assert_equal [
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.1',
+      '   ->   Lock timeout is now set to 0.325',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.325',
+      '   ->   Lock timeout is now set to 0.55',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.55',
+      '   ->   Lock timeout is now set to 0.775',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.775',
+      '   ->   Lock timeout is now set to 1',
+      '   -> Retrying now.',
+    ], calls[1..-1].map(&:first)
+
+  end
+
+  private
+
+  def calls_for_lock_timeout_migration
+    @migration = Class.new(ActiveRecord::Migration::Current) do
+      def up
+        connection.send(:retry_if_lock_timeout) do
+          raise ActiveRecord::LockWaitTimeout, 'PG::LockNotAvailable: ERROR:  canceling statement due to lock timeout'
+        end
+      end
+    end.new
+
+    @connection.expects(:sleep).times(4)
+
+    calls =
+      record_calls(@migration, :write) do
+        run_migration
+        flunk 'run_migration should raise'
+      rescue StandardError => e
+        assert_instance_of ActiveRecord::LockWaitTimeout, e.cause
+        assert_includes e.cause.message, 'canceling statement due to lock timeout'
+      end
+
+    calls
   end
 end

--- a/test/statement_retrier_test.rb
+++ b/test/statement_retrier_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class StatementRetrierTest < Minitest::Test
-
   def test_lock_timeout_increase_on_retry
     SafePgMigrations.config.lock_timeout = 0.1.seconds
     SafePgMigrations.config.increase_lock_timeout_on_retry = true
@@ -11,23 +10,23 @@ class StatementRetrierTest < Minitest::Test
     calls = calls_for_lock_timeout_migration
 
     assert_equal [
-                   '   -> Retrying in 60 seconds...',
-                   '   ->   Increasing the lock timeout... Currently set to 0.1',
-                   '   ->   Lock timeout is now set to 0.325',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   ->   Increasing the lock timeout... Currently set to 0.325',
-                   '   ->   Lock timeout is now set to 0.55',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   ->   Increasing the lock timeout... Currently set to 0.55',
-                   '   ->   Lock timeout is now set to 0.775',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   ->   Increasing the lock timeout... Currently set to 0.775',
-                   '   ->   Lock timeout is now set to 1',
-                   '   -> Retrying now.',
-                 ], calls[1..-1].map(&:first)
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.1',
+      '   ->   Lock timeout is now set to 0.325',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.325',
+      '   ->   Lock timeout is now set to 0.55',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.55',
+      '   ->   Lock timeout is now set to 0.775',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   ->   Increasing the lock timeout... Currently set to 0.775',
+      '   ->   Lock timeout is now set to 1',
+      '   -> Retrying now.',
+    ], calls[1..].map(&:first)
   end
 
   def test_no_lock_timeout_increase_on_retry_if_disabled
@@ -37,15 +36,15 @@ class StatementRetrierTest < Minitest::Test
     calls = calls_for_lock_timeout_migration
 
     assert_equal [
-                   '   -> Retrying in 60 seconds...',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   -> Retrying now.',
-                   '   -> Retrying in 60 seconds...',
-                   '   -> Retrying now.',
-                 ], calls[1..-1].map(&:first)
+      '   -> Retrying in 60 seconds...',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   -> Retrying now.',
+      '   -> Retrying in 60 seconds...',
+      '   -> Retrying now.',
+    ], calls[1..].map(&:first)
   end
 
   def test_retry_if_lock_timeout
@@ -90,7 +89,6 @@ class StatementRetrierTest < Minitest::Test
     end.new
 
     @connection.expects(:sleep).times(4)
-
 
     record_calls(@migration, :write) do
       run_migration


### PR DESCRIPTION
## Context
Many times the background migrations failed just because the lock timeout was too short.
In this PR we increase the lock_timeout gradually upon retries to help make the migration pass.