### PR TITLE
Fix check used when adding non null constraint

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_insurer/change_column_null.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer/change_column_null.rb
@@ -27,7 +27,7 @@ module SafePgMigrations
       private
 
       def check_constraint_by_expression(table_name, expression)
-        check_constraints(table_name).detect { |check_constraint| check_constraint.expression = expression }
+        check_constraints(table_name).detect { |check_constraint| check_constraint.expression == expression }
       end
 
       def should_create_constraint?(default, null)

--- a/test/StatementInsurer/change_column_null_test.rb
+++ b/test/StatementInsurer/change_column_null_test.rb
@@ -99,6 +99,23 @@ module StatementInsurer
       CALLS
     end
 
+    def test_when_a_non_matching_check_constraint_exists_creates_new_constraint
+      skip_if_unmet_requirements!
+
+      @connection.add_check_constraint :users, 'length(email) > 5', name: 'chk_email_length', validate: true
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            change_column_null(:users, :email, false)
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls met_requirements? ? safe_pg_calls : base_calls, calls
+    end
+
     private
 
     def safe_pg_calls


### PR DESCRIPTION
When changing a column to non-null, we try to look for existing check constraints on the column based on the expression. There seems to however be a typo, and currently, we're taking the first check constraint, whatever it is, from the table.

This PR fixes this, by fixing the typo, and adds a test, which currently fails in master.