### PR TITLE
chore(EN-1035): move jobs on the new gh infra

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -28,7 +28,7 @@ jobs:
   check_pr_title:
     name: Check PR title
     if: '!github.event.pull_request.draft'
-    runs-on: ubuntu-latest
+    runs-on: prod-linux-xs
     steps:
       - name: Check PR title
         uses: doctolib/actions/check-pr-title@main

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   rubocop-test:
     name: Rubocop
-    runs-on: ubuntu-latest
+    runs-on: prod-linux-xs
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
@@ -27,7 +27,7 @@ jobs:
         run: bundle exec rubocop
   unit-test:
     name: UnitTest
-    runs-on: ubuntu-latest
+    runs-on: prod-linux-s
     # Service containers to run with `container-job`
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
       - name: Run tests
         run: bundle exec rake test
   legacy-activerecord-test:
-    runs-on: ubuntu-latest
+    runs-on: prod-linux-s
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Move all workflows on the new github runners infrastructure

https://doctolib.atlassian.net/browse/EN-1035