### PR TITLE
Fix add/remove_index detail in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ It is also possible to set a threshold for the table size, above which the migra
 
 Creating an index requires a `SHARE` lock on the target table which blocks all write on the table while the index is created (which can take some time on a large table). This is usually not practical in a live environment. Thus, **Safe PG Migrations** ensures indexes are created concurrently.
 
-As `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` are non-blocking operations (ie: read/write operations on the table are still possible), **Safe PG Migrations** sets a lock timeout to 30 seconds for those 2 specific statements.
+As `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` are non-blocking operations (ie: read/write operations on the table are still possible), **Safe PG Migrations** sets a statement and lock timeout to 0 seconds for those 2 specific statements.
 
 If you still get lock timeout while adding / removing indexes, it might be for one of those reasons:
 


### PR DESCRIPTION
Both `add_index` and `remove_index` use `without_timeout(&)`, so they don't set a lock timeout of 30 seconds =)

See https://github.com/doctolib/safe-pg-migrations/blob/b0efa6d52d304f22eb9fdba5e94448c3bde00467/lib/safe-pg-migrations/plugins/statement_insurer.rb#L64 and https://github.com/doctolib/safe-pg-migrations/blob/b0efa6d52d304f22eb9fdba5e94448c3bde00467/lib/safe-pg-migrations/plugins/statement_insurer.rb#L71