### PR TITLE
Handle cases when the blocking query xact_start is null (for logging)

### DIFF
--- a/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
+++ b/lib/safe-pg-migrations/helpers/blocking_activity_formatter.rb
@@ -41,7 +41,7 @@ module SafePgMigrations
         queries.each do |start_time, locktype, mode, pid, transactionid|
           Logger.say <<~MESSAGE.squish, sub_item: true, sensitive: true
             Query with pid #{pid || 'null'}
-            started #{format_start_time(start_time)}:
+            started #{start_time ? format_start_time(start_time) : 'unknown'}:
             lock type: #{locktype || 'null'},
             lock mode: #{mode || 'null'},
             lock transactionid: #{transactionid || 'null'}",


### PR DESCRIPTION
We had issue logging blocking queries because for unknown reason we did not retrieved `xact_start` from `pg_stat_activity`.
We were trying to parse `nil` as a `string`.. 

Now we  will display `'unknown'` in this case