### PR TITLE
chore(BLUE-129): pin setup-ruby action

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -50,7 +50,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
Pinning github actions (and pinning to specific versions in general) gives us more security regarding our supply chain. This 3rd-party action (apart from official github ones) is the only one on which this is not restricted, let's fix that!