### PR TITLE
fix: allow backfilling a FALSE default with update_in_batches

### DIFF
--- a/lib/safe-pg-migrations/plugins/statement_insurer/add_column.rb
+++ b/lib/safe-pg-migrations/plugins/statement_insurer/add_column.rb
@@ -39,7 +39,7 @@ module SafePgMigrations
       private
 
       def should_keep_default_implementation?(default: nil, default_value_backfill: :auto, **)
-        default_value_backfill != :update_in_batches || !default ||
+        default_value_backfill != :update_in_batches || default.nil? ||
           !Helpers::SatisfiedHelper.satisfies_add_column_update_rows_backfill?
       end
 

--- a/test/StatementInsurer/add_column_test.rb
+++ b/test/StatementInsurer/add_column_test.rb
@@ -157,6 +157,32 @@ module StatementInsurer
       ], calls
     end
 
+    def test_with_default_value_backfill_algorithm_and_false_default
+      skip_if_unmet_requirements!
+
+      @migration =
+        Class.new(ActiveRecord::Migration::Current) do
+          def change
+            add_column :users, :active, :boolean, default: false, null: false,
+                                                  default_value_backfill: :update_in_batches
+          end
+        end.new
+
+      calls = record_calls(@connection, :execute) { run_migration }
+
+      assert_calls [
+        'ALTER TABLE "users" ADD "active" boolean',
+        'ALTER TABLE "users" ALTER COLUMN "active" SET DEFAULT FALSE',
+        # exec_calls goes here
+        'ALTER TABLE "users" ADD CONSTRAINT chk_rails_7c13a48bf9 CHECK (active IS NOT NULL) NOT VALID',
+        'SET statement_timeout TO 0',
+        'ALTER TABLE "users" VALIDATE CONSTRAINT "chk_rails_7c13a48bf9"',
+        "SET statement_timeout TO '5s'",
+        'ALTER TABLE "users" ALTER COLUMN "active" SET NOT NULL',
+        'ALTER TABLE "users" DROP CONSTRAINT "chk_rails_7c13a48bf9"',
+      ], calls
+    end
+
     def test_backfill_in_multiple_steps
       skip_if_unmet_requirements!
 


### PR DESCRIPTION
Fixes #173

## The bug

```ruby
add_column :users, :active, :boolean, default: false, null: false,
                                      default_value_backfill: :update_in_batches
```

emits a single statement:

```sql
ALTER TABLE "users" ADD "active" boolean DEFAULT FALSE NOT NULL
```

The safe multi-step path is skipped entirely — no separate `SET DEFAULT`, no `NOT VALID` check constraint, no batched backfill. Silently, with no warning.

## Why

`should_keep_default_implementation?` guarded on `!default`:

```ruby
default_value_backfill != :update_in_batches || !default || ...
```

In Ruby `!false` is `true`, exactly like `!nil`. So `default: false` was read as "no default was given" and the method returned `true`, sending the call straight to `super`.

The intent is "no default given", which is `default.nil?`. `false` is a perfectly legitimate value to backfill — a NOT NULL boolean column is the obvious case, and the one @henrahmagix reported.

The three other guards are untouched, so `default_value_backfill: :auto`, `default: nil`, and unmet PG requirements all keep their current behaviour.

## Test

Added `test_with_default_value_backfill_algorithm_and_false_default`, mirroring the existing `test_with_default_value_backfill_algorithm` with a boolean column.

On `main` it fails with exactly the reported symptom:

```
- "ALTER TABLE \"users\" ADD \"active\" boolean",
- "ALTER TABLE \"users\" ALTER COLUMN \"active\" SET DEFAULT FALSE",
- "ALTER TABLE \"users\" ADD CONSTRAINT chk_rails_7c13a48bf9 CHECK (active IS NOT NULL) NOT VALID",
  ...
+ "ALTER TABLE \"users\" ADD \"active\" boolean DEFAULT FALSE NOT NULL",
```

With the fix it passes. Full suite locally: **127 runs, 379 assertions, 0 failures, 0 errors, 0 skips**. RuboCop clean on both files. Ran against PostgreSQL 16, Ruby 4.0.5.

Worth noting: `test_add_column_with_default_and_null_specified` already covers `default: false` *without* `default_value_backfill`, and still passes — that path short-circuits on the first guard, so it is unaffected.

## Credit

@henrahmagix diagnosed this precisely in #173 three months ago and offered to send a patch. I hope it is helpful rather than presumptuous that I went ahead — happy to close this if they would rather do it themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
